### PR TITLE
Refine home page layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,41 @@
+# AWARENET Website
+
+Questa è una pagina web statica pensata per presentare il network AWARENET. L'interfaccia richiama la struttura del sito [dynamical-inference.ai](https://dynamical-inference.ai/) con una barra di navigazione orizzontale che include il logo e le sezioni principali del sito.
+
+## Struttura del progetto
+
+```
+.
+├── assets
+│   ├── css
+│   │   └── styles.css      # Stili personalizzati del sito
+│   └── images
+│       └── logo.svg        # Logo vettoriale usato nella navbar
+├── index.html               # Pagina principale (Home)
+└── README.md                # Documentazione del progetto
+```
+
+## Contenuti della pagina
+
+La pagina `index.html` apre direttamente sulla **Home**, che comprende:
+
+- un hero introduttivo con titolo, descrizione e pulsante di invito all'azione;
+- un riquadro laterale con recapiti rapidi (email e indirizzo) per consentire il contatto immediato.
+
+La barra di navigazione mostra già le voci "Research", "Team", "News" e "Contact" per rispecchiare il menu desiderato, ma al momento sono disattivate in attesa di eventuali pagine dedicate.
+
+## Personalizzazione
+
+- Aggiorna il logo sostituendo `assets/images/logo.svg` con la tua versione (mantenendo lo stesso nome file oppure aggiornando il percorso nell'`<img>` della navbar).
+- Modifica i testi dell'hero e del riquadro contatti direttamente in `index.html` per adattarli ai contenuti reali.
+- Personalizza la palette di colori aggiornando le variabili CSS dichiarate in cima a `assets/css/styles.css`.
+
+## Anteprima locale
+
+Trattandosi di un sito statico è sufficiente aprire `index.html` in un browser moderno. Per una migliore esperienza di sviluppo puoi servire il sito con un piccolo server locale:
+
+```bash
+python3 -m http.server
+```
+
+Visitando `http://localhost:8000` potrai navigare il sito e testare il comportamento della barra di navigazione responsive.

--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -1,0 +1,242 @@
+:root {
+    --color-primary: #1b2a4b;
+    --color-secondary: #3e7cb1;
+    --color-background: #f5f7fb;
+    --color-surface: #ffffff;
+    --color-text: #1d1d1f;
+    --color-muted: #5f6c7b;
+    --color-accent: #f0b429;
+    --font-family: 'Montserrat', sans-serif;
+    --shadow-sm: 0 4px 12px rgba(16, 24, 40, 0.08);
+}
+
+* {
+    box-sizing: border-box;
+}
+
+body {
+    margin: 0;
+    font-family: var(--font-family);
+    color: var(--color-text);
+    background: var(--color-background);
+    line-height: 1.6;
+}
+
+img {
+    max-width: 100%;
+    display: block;
+}
+
+a {
+    color: inherit;
+    text-decoration: none;
+}
+
+a:hover,
+a:focus {
+    color: var(--color-secondary);
+}
+
+.site-header {
+    position: sticky;
+    top: 0;
+    z-index: 100;
+    background: rgba(255, 255, 255, 0.9);
+    backdrop-filter: blur(12px);
+    border-bottom: 1px solid rgba(27, 42, 75, 0.08);
+}
+
+.navbar {
+    margin: 0 auto;
+    max-width: 1100px;
+    padding: 0.75rem 1.5rem;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1.5rem;
+}
+
+.navbar__brand {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.75rem;
+    font-weight: 600;
+    font-size: 1.1rem;
+    color: var(--color-primary);
+}
+
+.navbar__logo {
+    width: 44px;
+    height: auto;
+}
+
+.navbar__toggle {
+    display: none;
+    background: none;
+    border: none;
+    font-size: 1.75rem;
+    line-height: 1;
+    cursor: pointer;
+    color: var(--color-primary);
+}
+
+.navbar__menu {
+    display: flex;
+    align-items: center;
+    gap: 1.5rem;
+    list-style: none;
+    margin: 0;
+    padding: 0;
+}
+
+.navbar__link {
+    font-weight: 500;
+    font-size: 0.95rem;
+    position: relative;
+    padding-bottom: 0.25rem;
+}
+
+.navbar__link::after {
+    content: '';
+    position: absolute;
+    left: 0;
+    bottom: 0;
+    width: 100%;
+    height: 2px;
+    background: var(--color-secondary);
+    transform: scaleX(0);
+    transform-origin: bottom right;
+    transition: transform 0.3s ease;
+}
+
+.navbar__link:focus::after,
+.navbar__link:hover::after {
+    transform: scaleX(1);
+    transform-origin: bottom left;
+}
+
+.navbar__link--disabled {
+    color: var(--color-muted);
+    cursor: default;
+    pointer-events: none;
+}
+
+.navbar__link--disabled::after {
+    display: none;
+}
+
+.section {
+    padding: 5rem 1.5rem;
+}
+
+.section--hero {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+    gap: 2.5rem;
+    align-items: center;
+    padding: 6rem 1.5rem 5rem;
+    background: radial-gradient(circle at 20% 20%, rgba(62, 124, 177, 0.18), transparent 55%),
+        radial-gradient(circle at 80% 0%, rgba(240, 180, 41, 0.2), transparent 45%),
+        var(--color-surface);
+    max-width: 1100px;
+    margin: 0 auto;
+}
+
+.section--hero h1 {
+    font-size: clamp(2.25rem, 5vw, 3.5rem);
+    margin-bottom: 1rem;
+    color: var(--color-primary);
+}
+
+.section--hero p {
+    max-width: 540px;
+    color: var(--color-muted);
+    font-size: 1.05rem;
+}
+
+.section__content {
+    display: grid;
+    gap: 1.75rem;
+    max-width: 540px;
+}
+
+.hero-highlight {
+    background: rgba(62, 124, 177, 0.08);
+    border: 1px solid rgba(62, 124, 177, 0.25);
+    border-radius: 18px;
+    padding: 2rem;
+    box-shadow: var(--shadow-sm);
+    color: var(--color-primary);
+}
+
+.hero-highlight p {
+    margin: 0 0 0.75rem;
+    font-size: 1rem;
+}
+
+.hero-highlight p:last-child {
+    margin-bottom: 0;
+}
+
+.button {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding: 0.75rem 1.5rem;
+    border-radius: 999px;
+    background: var(--color-secondary);
+    color: white;
+    font-weight: 600;
+    transition: transform 0.2s ease, box-shadow 0.2s ease;
+    box-shadow: var(--shadow-sm);
+}
+
+.button:hover,
+.button:focus {
+    transform: translateY(-3px);
+    box-shadow: 0 10px 24px rgba(62, 124, 177, 0.35);
+}
+
+.button--secondary {
+    background: var(--color-primary);
+}
+
+.site-footer {
+    text-align: center;
+    padding: 2rem 1rem;
+    background: var(--color-primary);
+    color: white;
+    font-size: 0.9rem;
+}
+
+@media (max-width: 820px) {
+    .navbar__toggle {
+        display: inline-flex;
+    }
+
+    .navbar__menu {
+        position: absolute;
+        inset: 72px 1.5rem auto;
+        flex-direction: column;
+        background: var(--color-surface);
+        border-radius: 14px;
+        padding: 1.25rem;
+        box-shadow: var(--shadow-sm);
+        opacity: 0;
+        pointer-events: none;
+        transform: translateY(-10px);
+        transition: opacity 0.2s ease, transform 0.2s ease;
+    }
+
+    .navbar__menu--open {
+        opacity: 1;
+        pointer-events: auto;
+        transform: translateY(0);
+    }
+}
+
+@media (max-width: 600px) {
+    .section {
+        padding: 4rem 1.25rem;
+    }
+}

--- a/assets/images/logo.svg
+++ b/assets/images/logo.svg
@@ -1,0 +1,17 @@
+<svg width="120" height="120" viewBox="0 0 120 120" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="title desc">
+  <title id="title">AWARENET logo</title>
+  <desc id="desc">Logo astratto con nodi connessi che formano una lettera A stilizzata</desc>
+  <defs>
+    <linearGradient id="gradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#3e7cb1" />
+      <stop offset="100%" stop-color="#1b2a4b" />
+    </linearGradient>
+  </defs>
+  <circle cx="60" cy="60" r="56" fill="url(#gradient)" opacity="0.18" />
+  <path d="M60 18l28 84h-12l-6.8-22.8H50.8L44 102H32L60 18zm2 49.8l-6-19.8-6.2 19.8H62z" fill="#1b2a4b" />
+  <g fill="#f0b429">
+    <circle cx="60" cy="18" r="4" />
+    <circle cx="88" cy="102" r="4" />
+    <circle cx="32" cy="102" r="4" />
+  </g>
+</svg>

--- a/index.html
+++ b/index.html
@@ -1,0 +1,61 @@
+<!DOCTYPE html>
+<html lang="it">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>AWARENET</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;500;600;700&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="assets/css/styles.css">
+</head>
+<body>
+    <header class="site-header">
+        <nav class="navbar">
+            <a class="navbar__brand" href="#home" aria-label="AWARENET">
+                <img src="assets/images/logo.svg" alt="AWARENET logo" class="navbar__logo">
+                <span class="navbar__title">AWARENET</span>
+            </a>
+            <button class="navbar__toggle" aria-expanded="false" aria-controls="primary-navigation">☰</button>
+            <ul id="primary-navigation" class="navbar__menu">
+                <li class="navbar__item"><a href="#home" class="navbar__link">Home</a></li>
+                <li class="navbar__item"><a href="#" class="navbar__link navbar__link--disabled" aria-disabled="true" tabindex="-1">Research</a></li>
+                <li class="navbar__item"><a href="#" class="navbar__link navbar__link--disabled" aria-disabled="true" tabindex="-1">Team</a></li>
+                <li class="navbar__item"><a href="#" class="navbar__link navbar__link--disabled" aria-disabled="true" tabindex="-1">News</a></li>
+                <li class="navbar__item"><a href="#" class="navbar__link navbar__link--disabled" aria-disabled="true" tabindex="-1">Contact</a></li>
+            </ul>
+        </nav>
+    </header>
+
+    <main>
+        <section id="home" class="section section--hero" aria-labelledby="home-title">
+            <div class="section__content">
+                <h1 id="home-title">Benvenuti in AWARENET</h1>
+                <p>Un network multidisciplinare dedicato allo sviluppo di soluzioni di intelligenza artificiale responsabile e interpretabile.</p>
+                <a class="button" href="#contattaci">Contattaci</a>
+            </div>
+            <aside class="hero-highlight" id="contattaci" aria-label="Contatti rapidi">
+                <p><strong>Email:</strong> <a href="mailto:info@awarenet.org">info@awarenet.org</a></p>
+                <p><strong>Indirizzo:</strong> Via dell'Innovazione 42, 35100 Padova (PD)</p>
+            </aside>
+        </section>
+    </main>
+
+    <footer class="site-footer">
+        <p>&copy; <span id="current-year"></span> AWARENET. Tutti i diritti riservati.</p>
+    </footer>
+
+    <script>
+        const toggleButton = document.querySelector('.navbar__toggle');
+        const navigation = document.querySelector('#primary-navigation');
+
+        toggleButton.addEventListener('click', () => {
+            const expanded = toggleButton.getAttribute('aria-expanded') === 'true';
+            toggleButton.setAttribute('aria-expanded', String(!expanded));
+            navigation.classList.toggle('navbar__menu--open');
+        });
+
+        document.getElementById('current-year').textContent = new Date().getFullYear();
+    </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- simplify the landing page to only include the home hero with a contact highlight instead of multiple sections
- adjust navigation styling so future menu items appear disabled until their pages exist
- update the README to describe the single-page home content and how to customize it

## Testing
- python3 -m http.server 8000

------
https://chatgpt.com/codex/tasks/task_e_68dfd990151c832b947101b6fff3a844