### PR TITLE
Translate homepage content to English

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="it">
+<html lang="en">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -30,111 +30,111 @@
     <main>
         <section id="home" class="section section--hero" aria-labelledby="home-title">
             <div class="section__content">
-                <h1 id="home-title">Benvenuti in AWARENET</h1>
-                <p>Un network multidisciplinare dedicato allo sviluppo di soluzioni di intelligenza artificiale responsabile e interpretabile.</p>
-                <a class="button" href="#contattaci">Contattaci</a>
+                <h1 id="home-title">Discover AWARENET: mapping the brain’s pathways to consciousness</h1>
+                <p>A multidisciplinary network dedicated to developing responsible, interpretable artificial intelligence solutions informed by cutting-edge neuroscience.</p>
+                <a class="button" href="#contact">Contact us</a>
             </div>
-            <aside class="hero-highlight" id="contattaci" aria-label="Contatti rapidi">
+            <aside class="hero-highlight" aria-label="Quick contacts">
                 <p><strong>Email:</strong> <a href="mailto:info@awarenet.org">info@awarenet.org</a></p>
-                <p><strong>Indirizzo:</strong> Via dell'Innovazione 42, 35100 Padova (PD)</p>
+                <p><strong>Address:</strong> Via dell'Innovazione 42, 35100 Padova (PD)</p>
             </aside>
         </section>
         <section id="research" class="section section--surface" aria-labelledby="research-title">
             <div class="section__heading">
-                <h2 id="research-title">Ricerca interdisciplinare</h2>
-                <p>Mettiamo in collaborazione scienziati dei dati, esperti di etica e professionisti del settore per trasformare la ricerca sull'intelligenza artificiale in soluzioni affidabili e responsabili.</p>
+                <h2 id="research-title">Interdisciplinary research</h2>
+                <p>We bring together data scientists, ethicists, and industry leaders to transform artificial intelligence research into trustworthy, responsible solutions.</p>
             </div>
             <div class="card-grid">
                 <article class="card" aria-labelledby="research-interpretability">
-                    <h3 id="research-interpretability">Interpretabilità dei modelli</h3>
-                    <p>Sviluppiamo strumenti che permettono di spiegare in modo trasparente le decisioni dei sistemi di machine learning, con un focus su settori regolamentati.</p>
+                    <h3 id="research-interpretability">Model interpretability</h3>
+                    <p>We develop tools that transparently explain machine learning decisions, with a focus on highly regulated sectors.</p>
                 </article>
                 <article class="card" aria-labelledby="research-governance">
-                    <h3 id="research-governance">Governance e compliance</h3>
-                    <p>Definiamo framework organizzativi che aiutano le aziende a rispettare linee guida e normative emergenti come l'AI Act europeo.</p>
+                    <h3 id="research-governance">Governance and compliance</h3>
+                    <p>We define organizational frameworks that help companies comply with emerging guidelines and regulations such as the European AI Act.</p>
                 </article>
                 <article class="card" aria-labelledby="research-impact">
-                    <h3 id="research-impact">Impatto sociale</h3>
-                    <p>Analizziamo gli effetti dell'adozione dell'IA sulle comunità per promuovere una trasformazione digitale equa e sostenibile.</p>
+                    <h3 id="research-impact">Social impact</h3>
+                    <p>We analyze the effects of AI adoption on communities to promote an equitable and sustainable digital transformation.</p>
                 </article>
             </div>
         </section>
 
         <section id="team" class="section section--muted" aria-labelledby="team-title">
             <div class="section__heading">
-                <h2 id="team-title">Un network di professionisti</h2>
-                <p>Ricercatori universitari, start-up tecnologiche e partner istituzionali lavorano insieme per accelerare l'innovazione responsabile.</p>
+                <h2 id="team-title">A network of professionals</h2>
+                <p>University researchers, tech startups, and institutional partners collaborate to accelerate responsible innovation.</p>
             </div>
-            <div class="timeline" aria-label="Storia del network">
+            <div class="timeline" aria-label="Network history">
                 <div class="timeline__event">
                     <span class="timeline__year">2019</span>
-                    <p>Fondazione di AWARENET con l'obiettivo di connettere le eccellenze italiane sulla ricerca responsabile.</p>
+                    <p>AWARENET is founded with the goal of connecting Italian excellence in responsible research.</p>
                 </div>
                 <div class="timeline__event">
                     <span class="timeline__year">2021</span>
-                    <p>Creazione dei primi laboratori congiunti con enti pubblici e imprese per progetti pilota su IA interpretabile.</p>
+                    <p>Launch of the first joint labs with public entities and companies for interpretable AI pilot projects.</p>
                 </div>
                 <div class="timeline__event">
                     <span class="timeline__year">2023</span>
-                    <p>Avvio del programma di mentoring per startup early-stage impegnate nello sviluppo di soluzioni AI etiche.</p>
+                    <p>Start of a mentoring program for early-stage startups developing ethical AI solutions.</p>
                 </div>
             </div>
         </section>
 
         <section id="news" class="section section--surface" aria-labelledby="news-title">
             <div class="section__heading">
-                <h2 id="news-title">Aggiornamenti</h2>
-                <p>Eventi, pubblicazioni e opportunità per rimanere informati sulle nostre attività.</p>
+                <h2 id="news-title">Updates</h2>
+                <p>Events, publications, and opportunities to stay informed about our activities.</p>
             </div>
             <div class="news-grid">
                 <article class="news-item">
-                    <h3>Workshop "AI Responsabile"</h3>
-                    <p>Una giornata di formazione congiunta con università e imprese per condividere best practice sull'implementazione di sistemi trasparenti.</p>
-                    <a class="button button--secondary" href="#contact">Partecipa</a>
+                    <h3>"Responsible AI" workshop</h3>
+                    <p>A collaborative training day with universities and companies to share best practices on implementing transparent systems.</p>
+                    <a class="button button--secondary" href="#contact">Join us</a>
                 </article>
                 <article class="news-item">
-                    <h3>Report annuale 2024</h3>
-                    <p>Scopri come i progetti finanziati da AWARENET hanno migliorato la tracciabilità dei processi decisionali grazie a strumenti di explainable AI.</p>
-                    <a class="button button--secondary" href="#contact">Scarica ora</a>
+                    <h3>2024 annual report</h3>
+                    <p>Discover how AWARENET-funded projects improved decision-process traceability through explainable AI tools.</p>
+                    <a class="button button--secondary" href="#contact">Download now</a>
                 </article>
             </div>
         </section>
 
         <section id="contact" class="section section--muted" aria-labelledby="contact-title">
             <div class="section__heading">
-                <h2 id="contact-title">Collabora con noi</h2>
-                <p>Scrivici per proporre nuove iniziative, richiedere una consulenza o entrare a far parte del network AWARENET.</p>
+                <h2 id="contact-title">Collaborate with us</h2>
+                <p>Write to us to propose new initiatives, request consulting, or join the AWARENET network.</p>
             </div>
             <div class="contact-panel">
                 <div>
-                    <h3>Contatti principali</h3>
+                    <h3>Main contacts</h3>
                     <ul class="contact-list">
                         <li><strong>Email:</strong> <a href="mailto:info@awarenet.org">info@awarenet.org</a></li>
-                        <li><strong>Telefono:</strong> <a href="tel:+390497654321">+39 049 7654321</a></li>
-                        <li><strong>Indirizzo:</strong> Via dell'Innovazione 42, 35100 Padova (PD)</li>
+                        <li><strong>Phone:</strong> <a href="tel:+390497654321">+39 049 7654321</a></li>
+                        <li><strong>Address:</strong> Via dell'Innovazione 42, 35100 Padova (PD)</li>
                     </ul>
                 </div>
-                <form class="contact-form" aria-label="Modulo di contatto">
+                <form class="contact-form" aria-label="Contact form">
                     <div class="form-field">
-                        <label for="contact-name">Nome</label>
-                        <input type="text" id="contact-name" name="name" placeholder="Il tuo nome" required>
+                        <label for="contact-name">Name</label>
+                        <input type="text" id="contact-name" name="name" placeholder="Your name" required>
                     </div>
                     <div class="form-field">
                         <label for="contact-email">Email</label>
-                        <input type="email" id="contact-email" name="email" placeholder="nome@azienda.it" required>
+                        <input type="email" id="contact-email" name="email" placeholder="name@company.com" required>
                     </div>
                     <div class="form-field">
-                        <label for="contact-message">Messaggio</label>
-                        <textarea id="contact-message" name="message" rows="4" placeholder="Come possiamo aiutarti?" required></textarea>
+                        <label for="contact-message">Message</label>
+                        <textarea id="contact-message" name="message" rows="4" placeholder="How can we help you?" required></textarea>
                     </div>
-                    <button type="submit" class="button">Invia richiesta</button>
+                    <button type="submit" class="button">Send request</button>
                 </form>
             </div>
         </section>
     </main>
 
     <footer class="site-footer">
-        <p>&copy; <span id="current-year"></span> AWARENET. Tutti i diritti riservati.</p>
+        <p>&copy; <span id="current-year"></span> AWARENET. All rights reserved.</p>
     </footer>
 
     <script>


### PR DESCRIPTION
## Summary
- update the homepage hero title and introduction with the requested English messaging
- translate navigation, section headings, and body copy across the page to English
- refresh call-to-action labels and contact form text to match the new language

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dfe3806e30832bbea4e0f3801a99b5