### PR TITLE
Update AWARENET branding with new logo and gradient palette

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -3,13 +3,13 @@ html {
 }
 
 :root {
-    --color-primary: #1b2a4b;
-    --color-secondary: #3e7cb1;
-    --color-background: #f5f7fb;
+    --color-primary: #2b2d5c;
+    --color-secondary: #6f7bdc;
+    --color-background: #f2f1fb;
     --color-surface: #ffffff;
-    --color-text: #1d1d1f;
-    --color-muted: #5f6c7b;
-    --color-accent: #f0b429;
+    --color-text: #1f1f36;
+    --color-muted: #5c5b78;
+    --color-accent: #f1c7af;
     --font-family: 'Montserrat', sans-serif;
     --shadow-sm: 0 4px 12px rgba(16, 24, 40, 0.08);
 }
@@ -45,9 +45,9 @@ a:focus {
     position: sticky;
     top: 0;
     z-index: 100;
-    background: rgba(255, 255, 255, 0.9);
+    background: rgba(246, 245, 255, 0.9);
     backdrop-filter: blur(12px);
-    border-bottom: 1px solid rgba(27, 42, 75, 0.08);
+    border-bottom: 1px solid rgba(43, 45, 92, 0.08);
 }
 
 .navbar {
@@ -145,7 +145,7 @@ a:focus {
 }
 
 .section--muted {
-    background: linear-gradient(135deg, rgba(27, 42, 75, 0.08), rgba(62, 124, 177, 0.05));
+    background: linear-gradient(140deg, rgba(111, 123, 220, 0.15), rgba(79, 118, 204, 0.08));
     border-radius: 24px;
     padding: 5rem clamp(1.25rem, 4vw, 3rem);
 }
@@ -156,8 +156,9 @@ a:focus {
     gap: 2.5rem;
     align-items: center;
     padding: 6rem 1.5rem 5rem;
-    background: radial-gradient(circle at 20% 20%, rgba(62, 124, 177, 0.18), transparent 55%),
-        radial-gradient(circle at 80% 0%, rgba(240, 180, 41, 0.2), transparent 45%),
+    background: radial-gradient(circle at 18% 22%, rgba(111, 123, 220, 0.22), transparent 55%),
+        radial-gradient(circle at 80% -5%, rgba(241, 199, 175, 0.28), transparent 45%),
+        radial-gradient(circle at 50% 120%, rgba(79, 118, 204, 0.18), transparent 55%),
         var(--color-surface);
     max-width: 1100px;
     margin: 0 auto;
@@ -208,8 +209,8 @@ a:focus {
 }
 
 .card {
-    background: rgba(62, 124, 177, 0.08);
-    border: 1px solid rgba(62, 124, 177, 0.2);
+    background: rgba(111, 123, 220, 0.08);
+    border: 1px solid rgba(79, 118, 204, 0.22);
     border-radius: 18px;
     padding: 2rem;
     box-shadow: var(--shadow-sm);
@@ -237,7 +238,7 @@ a:focus {
     gap: 0.5rem;
     padding: 1.5rem;
     border-left: 4px solid var(--color-secondary);
-    background: rgba(255, 255, 255, 0.6);
+    background: rgba(255, 255, 255, 0.68);
     border-radius: 14px;
 }
 
@@ -262,8 +263,8 @@ a:focus {
     gap: 1rem;
     padding: 2rem;
     border-radius: 18px;
-    border: 1px solid rgba(27, 42, 75, 0.08);
-    background: rgba(255, 255, 255, 0.85);
+    border: 1px solid rgba(43, 45, 92, 0.08);
+    background: rgba(255, 255, 255, 0.88);
     box-shadow: var(--shadow-sm);
 }
 
@@ -303,7 +304,7 @@ a:focus {
     background: rgba(255, 255, 255, 0.85);
     border-radius: 18px;
     box-shadow: var(--shadow-sm);
-    border: 1px solid rgba(27, 42, 75, 0.08);
+    border: 1px solid rgba(43, 45, 92, 0.08);
 }
 
 .form-field {
@@ -318,7 +319,7 @@ a:focus {
 
 .form-field input,
 .form-field textarea {
-    border: 1px solid rgba(27, 42, 75, 0.15);
+    border: 1px solid rgba(43, 45, 92, 0.18);
     border-radius: 10px;
     padding: 0.75rem 1rem;
     font: inherit;
@@ -328,7 +329,7 @@ a:focus {
 
 .form-field input:focus,
 .form-field textarea:focus {
-    outline: 2px solid rgba(62, 124, 177, 0.45);
+    outline: 2px solid rgba(111, 123, 220, 0.45);
     outline-offset: 2px;
 }
 
@@ -337,8 +338,8 @@ a:focus {
 }
 
 .hero-highlight {
-    background: rgba(62, 124, 177, 0.08);
-    border: 1px solid rgba(62, 124, 177, 0.25);
+    background: rgba(111, 123, 220, 0.08);
+    border: 1px solid rgba(79, 118, 204, 0.25);
     border-radius: 18px;
     padding: 2rem;
     box-shadow: var(--shadow-sm);
@@ -360,7 +361,7 @@ a:focus {
     justify-content: center;
     padding: 0.75rem 1.5rem;
     border-radius: 999px;
-    background: var(--color-secondary);
+    background: linear-gradient(135deg, var(--color-secondary), #5a6bd2);
     color: white;
     font-weight: 600;
     transition: transform 0.2s ease, box-shadow 0.2s ease;
@@ -370,17 +371,17 @@ a:focus {
 .button:hover,
 .button:focus {
     transform: translateY(-3px);
-    box-shadow: 0 10px 24px rgba(62, 124, 177, 0.35);
+    box-shadow: 0 10px 24px rgba(111, 123, 220, 0.35);
 }
 
 .button--secondary {
-    background: var(--color-primary);
+    background: linear-gradient(135deg, var(--color-primary), #3f4ca1);
 }
 
 .site-footer {
     text-align: center;
     padding: 2rem 1rem;
-    background: var(--color-primary);
+    background: linear-gradient(135deg, var(--color-primary), #3f4ca1);
     color: white;
     font-size: 0.9rem;
 }

--- a/assets/images/logo.svg
+++ b/assets/images/logo.svg
@@ -1,17 +1,20 @@
 <svg width="120" height="120" viewBox="0 0 120 120" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="title desc">
   <title id="title">AWARENET logo</title>
-  <desc id="desc">Logo astratto con nodi connessi che formano una lettera A stilizzata</desc>
+  <desc id="desc">Logo con una forma di cervello morbida con gradiente nei toni lilla e blu</desc>
   <defs>
-    <linearGradient id="gradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" stop-color="#3e7cb1" />
-      <stop offset="100%" stop-color="#1b2a4b" />
+    <linearGradient id="brainGradient" x1="20%" y1="0%" x2="80%" y2="100%">
+      <stop offset="0%" stop-color="#f3d8c3" />
+      <stop offset="45%" stop-color="#b5a6ee" />
+      <stop offset="100%" stop-color="#5a78c9" />
+    </linearGradient>
+    <linearGradient id="accentStroke" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#6f7bdc" />
+      <stop offset="100%" stop-color="#3f4ca1" />
     </linearGradient>
   </defs>
-  <circle cx="60" cy="60" r="56" fill="url(#gradient)" opacity="0.18" />
-  <path d="M60 18l28 84h-12l-6.8-22.8H50.8L44 102H32L60 18zm2 49.8l-6-19.8-6.2 19.8H62z" fill="#1b2a4b" />
-  <g fill="#f0b429">
-    <circle cx="60" cy="18" r="4" />
-    <circle cx="88" cy="102" r="4" />
-    <circle cx="32" cy="102" r="4" />
+  <g fill="none" stroke-linecap="round" stroke-linejoin="round">
+    <path d="M60 14c-18.5 0-33.5 13.5-33.5 30.2v2.4C20 49.5 14 58.3 14 68.7 14 83 25.6 94.8 40.5 94.8h2.4C45.3 105 51.8 111 60 111s14.7-6 17.1-16.2h2.4C94.4 94.8 106 83 106 68.7c0-10.4-6-19.2-12.5-21.1v-3.4C93.5 28.3 78.5 14 60 14z" stroke="url(#accentStroke)" stroke-width="6" opacity="0.22" />
+    <path d="M60 20c-15.4 0-28 11.2-28 25.6v2.5c-6.1 2.4-11 8.5-11 16.2 0 9.8 8.2 17.6 18.2 17.6h1.8C42.8 93.6 50.5 100 60 100s17.2-6.4 19-18.1h1.8c10 0 18.2-7.9 18.2-17.6 0-7.7-4.9-13.9-11-16.2V45.6C88 31.2 75.4 20 60 20z" fill="url(#brainGradient)" stroke="#ffffff" stroke-width="2.5" />
+    <path d="M48 41.5c-2.7 0-5 2.2-5 4.9v8.3c0 2.7-2.3 4.9-5 4.9m19-29.2c-2.7 0-5 2.2-5 4.9v5.7c0 3-2.3 5.5-5.1 5.5m24.1-21.9c-2.7 0-5 2.2-5 4.9v11.8c0 3-2.3 5.4-5.1 5.4m19.1-5.4c-2.8 0-5.1 2.4-5.1 5.4v8.4c0 2.7-2.2 4.9-5 4.9" stroke="#3f4ca1" stroke-width="3" opacity="0.55" />
   </g>
 </svg>


### PR DESCRIPTION
## Summary
- replace the AWARENET logo with a soft gradient brain icon that matches the requested branding
- refresh the site color system to a muted lilac and blue gradient palette inspired by the new logo
- adjust hero, card, and button treatments to use the updated tones while maintaining readability

## Testing
- Not Run (static content)

------
https://chatgpt.com/codex/tasks/task_e_68dfe4163ea4832ba79ffb3c6758c133