### PR TITLE
Create responsive multi-page layout

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -20,6 +20,9 @@ html {
 
 body {
     margin: 0;
+    min-height: 100vh;
+    display: flex;
+    flex-direction: column;
     font-family: var(--font-family);
     color: var(--color-text);
     background: var(--color-background);
@@ -52,7 +55,7 @@ a:focus {
 
 .navbar {
     margin: 0 auto;
-    max-width: 1100px;
+    width: min(1200px, 92vw);
     padding: 0.75rem 1.5rem;
     display: flex;
     align-items: center;
@@ -119,6 +122,15 @@ a:focus {
     transform-origin: bottom left;
 }
 
+.navbar__link--active {
+    color: var(--color-secondary);
+}
+
+.navbar__link--active::after {
+    transform: scaleX(1);
+    transform-origin: bottom left;
+}
+
 .navbar__link--disabled {
     color: var(--color-muted);
     cursor: default;
@@ -131,7 +143,7 @@ a:focus {
 
 .section {
     padding: 5rem 1.5rem;
-    max-width: 1100px;
+    width: min(1200px, 92vw);
     margin: 0 auto;
     display: grid;
     gap: 2.5rem;
@@ -160,7 +172,7 @@ a:focus {
         radial-gradient(circle at 80% -5%, rgba(241, 199, 175, 0.28), transparent 45%),
         radial-gradient(circle at 50% 120%, rgba(79, 118, 204, 0.18), transparent 55%),
         var(--color-surface);
-    max-width: 1100px;
+    width: min(1200px, 92vw);
     margin: 0 auto;
     box-shadow: var(--shadow-sm);
     border-radius: 24px;
@@ -379,11 +391,19 @@ a:focus {
 }
 
 .site-footer {
+    margin-top: auto;
     text-align: center;
     padding: 2rem 1rem;
     background: linear-gradient(135deg, var(--color-primary), #3f4ca1);
     color: white;
     font-size: 0.9rem;
+}
+
+main {
+    flex: 1;
+    display: grid;
+    gap: clamp(3rem, 6vw, 4.5rem);
+    padding: clamp(2rem, 6vw, 4rem) 0;
 }
 
 @media (max-width: 820px) {

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -1,0 +1,24 @@
+const toggleButton = document.querySelector('.navbar__toggle');
+const navigation = document.querySelector('#primary-navigation');
+
+if (toggleButton && navigation) {
+    toggleButton.addEventListener('click', () => {
+        const expanded = toggleButton.getAttribute('aria-expanded') === 'true';
+        toggleButton.setAttribute('aria-expanded', String(!expanded));
+        navigation.classList.toggle('navbar__menu--open');
+    });
+
+    navigation.querySelectorAll('.navbar__link').forEach((link) => {
+        link.addEventListener('click', () => {
+            navigation.classList.remove('navbar__menu--open');
+            toggleButton.setAttribute('aria-expanded', 'false');
+        });
+    });
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+    const yearElement = document.getElementById('current-year');
+    if (yearElement) {
+        yearElement.textContent = new Date().getFullYear();
+    }
+});

--- a/contact.html
+++ b/contact.html
@@ -1,0 +1,110 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Contact | AWARENET</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;500;600;700&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="assets/css/styles.css">
+</head>
+<body>
+    <header class="site-header">
+        <nav class="navbar">
+            <a class="navbar__brand" href="index.html" aria-label="AWARENET">
+                <img src="assets/images/logo.svg" alt="AWARENET logo" class="navbar__logo">
+                <span class="navbar__title">AWARENET</span>
+            </a>
+            <button class="navbar__toggle" aria-expanded="false" aria-controls="primary-navigation">☰</button>
+            <ul id="primary-navigation" class="navbar__menu">
+                <li class="navbar__item"><a href="index.html" class="navbar__link">Home</a></li>
+                <li class="navbar__item"><a href="research.html" class="navbar__link">Research</a></li>
+                <li class="navbar__item"><a href="team.html" class="navbar__link">Team</a></li>
+                <li class="navbar__item"><a href="news.html" class="navbar__link">News</a></li>
+                <li class="navbar__item"><a href="contact.html" class="navbar__link navbar__link--active">Contact</a></li>
+            </ul>
+        </nav>
+    </header>
+
+    <main>
+        <section class="section section--hero" aria-labelledby="contact-hero-title">
+            <div class="section__content">
+                <h1 id="contact-hero-title">Collaborate with us</h1>
+                <p>Write to us to propose new initiatives, request consulting, or join the AWARENET network.</p>
+                <a class="button" href="mailto:info@awarenet.org">Send an email</a>
+            </div>
+            <aside class="hero-highlight" aria-label="Main contacts">
+                <p><strong>Email:</strong> <a href="mailto:info@awarenet.org">info@awarenet.org</a></p>
+                <p><strong>Phone:</strong> <a href="tel:+390497654321">+39 049 7654321</a></p>
+                <p><strong>Address:</strong> Via dell'Innovazione 42, 35100 Padova (PD)</p>
+            </aside>
+        </section>
+
+        <section class="section section--surface" aria-labelledby="contact-form-title">
+            <div class="section__heading">
+                <h2 id="contact-form-title">Send us a message</h2>
+                <p>We will respond within two business days with next steps tailored to your request.</p>
+            </div>
+            <div class="contact-panel">
+                <div>
+                    <h3>Main contacts</h3>
+                    <ul class="contact-list">
+                        <li><strong>Email:</strong> <a href="mailto:info@awarenet.org">info@awarenet.org</a></li>
+                        <li><strong>Phone:</strong> <a href="tel:+390497654321">+39 049 7654321</a></li>
+                        <li><strong>Address:</strong> Via dell'Innovazione 42, 35100 Padova (PD)</li>
+                    </ul>
+                    <h3>Office hours</h3>
+                    <p>Monday to Friday, 9:00 – 18:00 CET.</p>
+                </div>
+                <form class="contact-form" aria-label="Contact form">
+                    <div class="form-field">
+                        <label for="contact-name">Name</label>
+                        <input type="text" id="contact-name" name="name" placeholder="Your name" required>
+                    </div>
+                    <div class="form-field">
+                        <label for="contact-email">Email</label>
+                        <input type="email" id="contact-email" name="email" placeholder="name@company.com" required>
+                    </div>
+                    <div class="form-field">
+                        <label for="contact-organization">Organization</label>
+                        <input type="text" id="contact-organization" name="organization" placeholder="Company or institution">
+                    </div>
+                    <div class="form-field">
+                        <label for="contact-message">Message</label>
+                        <textarea id="contact-message" name="message" rows="4" placeholder="How can we help you?" required></textarea>
+                    </div>
+                    <button type="submit" class="button">Send request</button>
+                </form>
+            </div>
+        </section>
+
+        <section class="section section--muted" aria-labelledby="contact-visit-title">
+            <div class="section__heading">
+                <h2 id="contact-visit-title">Plan your visit</h2>
+                <p>Our headquarters is located in the Padova innovation district and is easily accessible by public transport.</p>
+            </div>
+            <div class="card-grid">
+                <article class="card">
+                    <h3>By train</h3>
+                    <p>We are 10 minutes away from Padova Centrale. From the station, take tram line SIR1 to “Ponti Romani”.</p>
+                </article>
+                <article class="card">
+                    <h3>By car</h3>
+                    <p>Parking is available at the Innovation Center. Please request a visitor permit 24 hours in advance.</p>
+                </article>
+                <article class="card">
+                    <h3>Accessibility</h3>
+                    <p>The venue is equipped with step-free access, assistive listening devices, and private meeting spaces.</p>
+                </article>
+            </div>
+        </section>
+    </main>
+
+    <footer class="site-footer">
+        <p>&copy; <span id="current-year"></span> AWARENET. All rights reserved.</p>
+    </footer>
+
+    <script src="assets/js/main.js"></script>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -12,123 +12,95 @@
 <body>
     <header class="site-header">
         <nav class="navbar">
-            <a class="navbar__brand" href="#home" aria-label="AWARENET">
+            <a class="navbar__brand" href="index.html" aria-label="AWARENET">
                 <img src="assets/images/logo.svg" alt="AWARENET logo" class="navbar__logo">
                 <span class="navbar__title">AWARENET</span>
             </a>
             <button class="navbar__toggle" aria-expanded="false" aria-controls="primary-navigation">☰</button>
             <ul id="primary-navigation" class="navbar__menu">
-                <li class="navbar__item"><a href="#home" class="navbar__link">Home</a></li>
-                <li class="navbar__item"><a href="#research" class="navbar__link">Research</a></li>
-                <li class="navbar__item"><a href="#team" class="navbar__link">Team</a></li>
-                <li class="navbar__item"><a href="#news" class="navbar__link">News</a></li>
-                <li class="navbar__item"><a href="#contact" class="navbar__link">Contact</a></li>
+                <li class="navbar__item"><a href="index.html" class="navbar__link navbar__link--active">Home</a></li>
+                <li class="navbar__item"><a href="research.html" class="navbar__link">Research</a></li>
+                <li class="navbar__item"><a href="team.html" class="navbar__link">Team</a></li>
+                <li class="navbar__item"><a href="news.html" class="navbar__link">News</a></li>
+                <li class="navbar__item"><a href="contact.html" class="navbar__link">Contact</a></li>
             </ul>
         </nav>
     </header>
 
     <main>
-        <section id="home" class="section section--hero" aria-labelledby="home-title">
+        <section class="section section--hero" aria-labelledby="home-title">
             <div class="section__content">
                 <h1 id="home-title">Discover AWARENET: mapping the brain’s pathways to consciousness</h1>
                 <p>A multidisciplinary network dedicated to developing responsible, interpretable artificial intelligence solutions informed by cutting-edge neuroscience.</p>
-                <a class="button" href="#contact">Contact us</a>
+                <a class="button" href="contact.html">Contact us</a>
             </div>
             <aside class="hero-highlight" aria-label="Quick contacts">
                 <p><strong>Email:</strong> <a href="mailto:info@awarenet.org">info@awarenet.org</a></p>
                 <p><strong>Address:</strong> Via dell'Innovazione 42, 35100 Padova (PD)</p>
             </aside>
         </section>
-        <section id="research" class="section section--surface" aria-labelledby="research-title">
+
+        <section class="section section--surface" aria-labelledby="about-title">
             <div class="section__heading">
-                <h2 id="research-title">Interdisciplinary research</h2>
-                <p>We bring together data scientists, ethicists, and industry leaders to transform artificial intelligence research into trustworthy, responsible solutions.</p>
+                <h2 id="about-title">What we do</h2>
+                <p>AWARENET unites academic excellence and entrepreneurial drive to turn trustworthy AI into a reality.</p>
             </div>
             <div class="card-grid">
-                <article class="card" aria-labelledby="research-interpretability">
-                    <h3 id="research-interpretability">Model interpretability</h3>
-                    <p>We develop tools that transparently explain machine learning decisions, with a focus on highly regulated sectors.</p>
+                <article class="card" aria-labelledby="about-research">
+                    <h3 id="about-research">Interdisciplinary research</h3>
+                    <p>From explainable models to governance frameworks, we develop tools that are ready for adoption in highly regulated environments.</p>
+                    <a class="button button--secondary" href="research.html">Explore our work</a>
                 </article>
-                <article class="card" aria-labelledby="research-governance">
-                    <h3 id="research-governance">Governance and compliance</h3>
-                    <p>We define organizational frameworks that help companies comply with emerging guidelines and regulations such as the European AI Act.</p>
+                <article class="card" aria-labelledby="about-team">
+                    <h3 id="about-team">An extended network</h3>
+                    <p>Universities, startups, and institutions collaborate within AWARENET to bridge fundamental research with industrial needs.</p>
+                    <a class="button button--secondary" href="team.html">Meet the team</a>
                 </article>
-                <article class="card" aria-labelledby="research-impact">
-                    <h3 id="research-impact">Social impact</h3>
-                    <p>We analyze the effects of AI adoption on communities to promote an equitable and sustainable digital transformation.</p>
-                </article>
-            </div>
-        </section>
-
-        <section id="team" class="section section--muted" aria-labelledby="team-title">
-            <div class="section__heading">
-                <h2 id="team-title">A network of professionals</h2>
-                <p>University researchers, tech startups, and institutional partners collaborate to accelerate responsible innovation.</p>
-            </div>
-            <div class="timeline" aria-label="Network history">
-                <div class="timeline__event">
-                    <span class="timeline__year">2019</span>
-                    <p>AWARENET is founded with the goal of connecting Italian excellence in responsible research.</p>
-                </div>
-                <div class="timeline__event">
-                    <span class="timeline__year">2021</span>
-                    <p>Launch of the first joint labs with public entities and companies for interpretable AI pilot projects.</p>
-                </div>
-                <div class="timeline__event">
-                    <span class="timeline__year">2023</span>
-                    <p>Start of a mentoring program for early-stage startups developing ethical AI solutions.</p>
-                </div>
-            </div>
-        </section>
-
-        <section id="news" class="section section--surface" aria-labelledby="news-title">
-            <div class="section__heading">
-                <h2 id="news-title">Updates</h2>
-                <p>Events, publications, and opportunities to stay informed about our activities.</p>
-            </div>
-            <div class="news-grid">
-                <article class="news-item">
-                    <h3>"Responsible AI" workshop</h3>
-                    <p>A collaborative training day with universities and companies to share best practices on implementing transparent systems.</p>
-                    <a class="button button--secondary" href="#contact">Join us</a>
-                </article>
-                <article class="news-item">
-                    <h3>2024 annual report</h3>
-                    <p>Discover how AWARENET-funded projects improved decision-process traceability through explainable AI tools.</p>
-                    <a class="button button--secondary" href="#contact">Download now</a>
+                <article class="card" aria-labelledby="about-news">
+                    <h3 id="about-news">Knowledge sharing</h3>
+                    <p>We publish reports, host workshops, and connect communities that are shaping the future of responsible artificial intelligence.</p>
+                    <a class="button button--secondary" href="news.html">Read the news</a>
                 </article>
             </div>
         </section>
 
-        <section id="contact" class="section section--muted" aria-labelledby="contact-title">
+        <section class="section section--muted" aria-labelledby="approach-title">
             <div class="section__heading">
-                <h2 id="contact-title">Collaborate with us</h2>
-                <p>Write to us to propose new initiatives, request consulting, or join the AWARENET network.</p>
+                <h2 id="approach-title">Our approach</h2>
+                <p>We map the journey from theoretical discovery to real-world solutions through transparent, iterative experimentation.</p>
             </div>
-            <div class="contact-panel">
-                <div>
-                    <h3>Main contacts</h3>
-                    <ul class="contact-list">
-                        <li><strong>Email:</strong> <a href="mailto:info@awarenet.org">info@awarenet.org</a></li>
-                        <li><strong>Phone:</strong> <a href="tel:+390497654321">+39 049 7654321</a></li>
-                        <li><strong>Address:</strong> Via dell'Innovazione 42, 35100 Padova (PD)</li>
-                    </ul>
+            <div class="timeline" aria-label="Highlights">
+                <div class="timeline__event">
+                    <span class="timeline__year">Collaborative labs</span>
+                    <p>Shared facilities allow mixed teams to validate AI explainability tools alongside neuroscientists and ethicists.</p>
                 </div>
-                <form class="contact-form" aria-label="Contact form">
-                    <div class="form-field">
-                        <label for="contact-name">Name</label>
-                        <input type="text" id="contact-name" name="name" placeholder="Your name" required>
-                    </div>
-                    <div class="form-field">
-                        <label for="contact-email">Email</label>
-                        <input type="email" id="contact-email" name="email" placeholder="name@company.com" required>
-                    </div>
-                    <div class="form-field">
-                        <label for="contact-message">Message</label>
-                        <textarea id="contact-message" name="message" rows="4" placeholder="How can we help you?" required></textarea>
-                    </div>
-                    <button type="submit" class="button">Send request</button>
-                </form>
+                <div class="timeline__event">
+                    <span class="timeline__year">Ethics by design</span>
+                    <p>We support organizations in embedding impact assessments into their development lifecycle from the very first prototype.</p>
+                </div>
+                <div class="timeline__event">
+                    <span class="timeline__year">Open knowledge</span>
+                    <p>Guidelines, datasets, and reference implementations are released to help the community reproduce our results.</p>
+                </div>
+            </div>
+        </section>
+
+        <section class="section section--surface" aria-labelledby="cta-title">
+            <div class="section__heading">
+                <h2 id="cta-title">Ready to collaborate?</h2>
+                <p>Join the conversation on responsible, human-centric AI and help us transform ideas into impact.</p>
+            </div>
+            <div class="card-grid">
+                <article class="card">
+                    <h3>Stay informed</h3>
+                    <p>Subscribe to our quarterly digest to receive curated updates on upcoming events and publications.</p>
+                    <a class="button" href="news.html">Visit the news hub</a>
+                </article>
+                <article class="card">
+                    <h3>Start a project</h3>
+                    <p>Let’s co-design initiatives that align with your organization’s ambitions and societal responsibilities.</p>
+                    <a class="button" href="contact.html">Get in touch</a>
+                </article>
             </div>
         </section>
     </main>
@@ -137,24 +109,6 @@
         <p>&copy; <span id="current-year"></span> AWARENET. All rights reserved.</p>
     </footer>
 
-    <script>
-        const toggleButton = document.querySelector('.navbar__toggle');
-        const navigation = document.querySelector('#primary-navigation');
-
-        toggleButton.addEventListener('click', () => {
-            const expanded = toggleButton.getAttribute('aria-expanded') === 'true';
-            toggleButton.setAttribute('aria-expanded', String(!expanded));
-            navigation.classList.toggle('navbar__menu--open');
-        });
-
-        navigation.querySelectorAll('.navbar__link').forEach((link) => {
-            link.addEventListener('click', () => {
-                navigation.classList.remove('navbar__menu--open');
-                toggleButton.setAttribute('aria-expanded', 'false');
-            });
-        });
-
-        document.getElementById('current-year').textContent = new Date().getFullYear();
-    </script>
+    <script src="assets/js/main.js"></script>
 </body>
 </html>

--- a/news.html
+++ b/news.html
@@ -1,0 +1,116 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>News | AWARENET</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;500;600;700&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="assets/css/styles.css">
+</head>
+<body>
+    <header class="site-header">
+        <nav class="navbar">
+            <a class="navbar__brand" href="index.html" aria-label="AWARENET">
+                <img src="assets/images/logo.svg" alt="AWARENET logo" class="navbar__logo">
+                <span class="navbar__title">AWARENET</span>
+            </a>
+            <button class="navbar__toggle" aria-expanded="false" aria-controls="primary-navigation">☰</button>
+            <ul id="primary-navigation" class="navbar__menu">
+                <li class="navbar__item"><a href="index.html" class="navbar__link">Home</a></li>
+                <li class="navbar__item"><a href="research.html" class="navbar__link">Research</a></li>
+                <li class="navbar__item"><a href="team.html" class="navbar__link">Team</a></li>
+                <li class="navbar__item"><a href="news.html" class="navbar__link navbar__link--active">News</a></li>
+                <li class="navbar__item"><a href="contact.html" class="navbar__link">Contact</a></li>
+            </ul>
+        </nav>
+    </header>
+
+    <main>
+        <section class="section section--hero" aria-labelledby="news-hero-title">
+            <div class="section__content">
+                <h1 id="news-hero-title">Updates, stories, and opportunities across the network</h1>
+                <p>Follow our community events, research breakthroughs, and publications to stay in the loop.</p>
+                <a class="button" href="contact.html">Share your news</a>
+            </div>
+            <aside class="hero-highlight" aria-label="News highlight">
+                <p><strong>Upcoming event:</strong> Responsible AI Summit — June 20, Padova</p>
+                <p><strong>Submission deadline:</strong> Call for workshops closes on May 15</p>
+            </aside>
+        </section>
+
+        <section class="section section--surface" aria-labelledby="news-latest">
+            <div class="section__heading">
+                <h2 id="news-latest">Latest highlights</h2>
+                <p>Discover the initiatives that our members are leading this season.</p>
+            </div>
+            <div class="news-grid">
+                <article class="news-item">
+                    <h3>"Responsible AI" workshop</h3>
+                    <p>A collaborative training day with universities and companies to share best practices on implementing transparent systems.</p>
+                    <a class="button button--secondary" href="contact.html">Join us</a>
+                </article>
+                <article class="news-item">
+                    <h3>2024 annual report</h3>
+                    <p>Discover how AWARENET-funded projects improved decision-process traceability through explainable AI tools.</p>
+                    <a class="button button--secondary" href="contact.html">Download now</a>
+                </article>
+                <article class="news-item">
+                    <h3>Ethical AI residency</h3>
+                    <p>Three startups are selected for an immersive residency program focusing on regulatory readiness and accountability.</p>
+                    <a class="button button--secondary" href="contact.html">Apply today</a>
+                </article>
+            </div>
+        </section>
+
+        <section class="section section--muted" aria-labelledby="news-resources">
+            <div class="section__heading">
+                <h2 id="news-resources">Resources</h2>
+                <p>Our publications and toolkits help teams scale responsible AI practices.</p>
+            </div>
+            <div class="card-grid">
+                <article class="card">
+                    <h3>Policy playbook</h3>
+                    <p>A curated set of templates to align governance with the evolving European AI Act.</p>
+                </article>
+                <article class="card">
+                    <h3>Explainability toolbox</h3>
+                    <p>Open-source libraries for model inspection, scenario analysis, and fairness assessments.</p>
+                </article>
+                <article class="card">
+                    <h3>Community newsletter</h3>
+                    <p>Quarterly insights from partners experimenting with responsible AI in complex settings.</p>
+                </article>
+            </div>
+        </section>
+
+        <section class="section section--surface" aria-labelledby="news-participate">
+            <div class="section__heading">
+                <h2 id="news-participate">Participate</h2>
+                <p>We welcome contributions from practitioners, policy-makers, and students.</p>
+            </div>
+            <div class="news-grid">
+                <article class="news-item">
+                    <h3>Call for speakers</h3>
+                    <p>Submit case studies, research talks, or live demos to feature in our community gatherings.</p>
+                </article>
+                <article class="news-item">
+                    <h3>Volunteer with us</h3>
+                    <p>Support outreach programs that bring responsible AI literacy to local schools and civic groups.</p>
+                </article>
+                <article class="news-item">
+                    <h3>Partner spotlights</h3>
+                    <p>Tell us about your latest achievements to be featured in the AWARENET spotlight series.</p>
+                </article>
+            </div>
+        </section>
+    </main>
+
+    <footer class="site-footer">
+        <p>&copy; <span id="current-year"></span> AWARENET. All rights reserved.</p>
+    </footer>
+
+    <script src="assets/js/main.js"></script>
+</body>
+</html>

--- a/research.html
+++ b/research.html
@@ -1,0 +1,113 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Research | AWARENET</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;500;600;700&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="assets/css/styles.css">
+</head>
+<body>
+    <header class="site-header">
+        <nav class="navbar">
+            <a class="navbar__brand" href="index.html" aria-label="AWARENET">
+                <img src="assets/images/logo.svg" alt="AWARENET logo" class="navbar__logo">
+                <span class="navbar__title">AWARENET</span>
+            </a>
+            <button class="navbar__toggle" aria-expanded="false" aria-controls="primary-navigation">☰</button>
+            <ul id="primary-navigation" class="navbar__menu">
+                <li class="navbar__item"><a href="index.html" class="navbar__link">Home</a></li>
+                <li class="navbar__item"><a href="research.html" class="navbar__link navbar__link--active">Research</a></li>
+                <li class="navbar__item"><a href="team.html" class="navbar__link">Team</a></li>
+                <li class="navbar__item"><a href="news.html" class="navbar__link">News</a></li>
+                <li class="navbar__item"><a href="contact.html" class="navbar__link">Contact</a></li>
+            </ul>
+        </nav>
+    </header>
+
+    <main>
+        <section class="section section--hero" aria-labelledby="research-hero-title">
+            <div class="section__content">
+                <h1 id="research-hero-title">Interdisciplinary research that keeps humans in the loop</h1>
+                <p>We develop reliable tools inspired by neuroscience to make artificial intelligence interpretable, measurable, and trustworthy.</p>
+                <a class="button" href="contact.html">Partner with us</a>
+            </div>
+            <aside class="hero-highlight" aria-label="Research pillars">
+                <p><strong>Focus areas:</strong> interpretability, governance, impact assessment</p>
+                <p><strong>Collaborators:</strong> Universities of Padova, Trento, and Milano-Bicocca</p>
+            </aside>
+        </section>
+
+        <section class="section section--surface" aria-labelledby="research-pillars">
+            <div class="section__heading">
+                <h2 id="research-pillars">Research pillars</h2>
+                <p>Each workstream combines fundamental discovery with real-world experimentation.</p>
+            </div>
+            <div class="card-grid">
+                <article class="card" aria-labelledby="research-interpretability">
+                    <h3 id="research-interpretability">Model interpretability</h3>
+                    <p>We build interfaces and metrics that allow practitioners to interrogate how complex models reach their decisions.</p>
+                </article>
+                <article class="card" aria-labelledby="research-governance">
+                    <h3 id="research-governance">Governance and compliance</h3>
+                    <p>Our researchers codify responsible AI requirements into actionable procedures aligned with the European AI Act.</p>
+                </article>
+                <article class="card" aria-labelledby="research-impact">
+                    <h3 id="research-impact">Social impact</h3>
+                    <p>We partner with public administrations to evaluate how algorithmic decisions affect communities and vulnerable groups.</p>
+                </article>
+            </div>
+        </section>
+
+        <section class="section section--muted" aria-labelledby="research-method-title">
+            <div class="section__heading">
+                <h2 id="research-method-title">Methodology</h2>
+                <p>Our approach blends scientific rigor with operational excellence to accelerate adoption.</p>
+            </div>
+            <div class="timeline" aria-label="Research methodology">
+                <div class="timeline__event">
+                    <span class="timeline__year">Hypothesis &amp; exploration</span>
+                    <p>We co-design research questions with domain specialists to ensure that new insights respond to concrete needs.</p>
+                </div>
+                <div class="timeline__event">
+                    <span class="timeline__year">Prototype &amp; validation</span>
+                    <p>Iterative prototyping and user studies demonstrate measurable improvements in transparency and accountability.</p>
+                </div>
+                <div class="timeline__event">
+                    <span class="timeline__year">Deployment &amp; guidance</span>
+                    <p>We support partners with policies, training, and governance to institutionalize responsible AI practices.</p>
+                </div>
+            </div>
+        </section>
+
+        <section class="section section--surface" aria-labelledby="research-projects">
+            <div class="section__heading">
+                <h2 id="research-projects">Current projects</h2>
+                <p>Discover a snapshot of experiments that are currently underway across the network.</p>
+            </div>
+            <div class="news-grid">
+                <article class="news-item">
+                    <h3>Neuro-symbolic observability</h3>
+                    <p>A collaboration with neuroscientists to map neural correlates of consciousness into symbolic AI explanations.</p>
+                </article>
+                <article class="news-item">
+                    <h3>Trust dashboards for health care</h3>
+                    <p>Building monitoring suites that surface drift, bias, and user feedback for clinical decision-support tools.</p>
+                </article>
+                <article class="news-item">
+                    <h3>Ethical sandbox</h3>
+                    <p>Testing regulatory scenarios with public administrations to refine impact assessments before production rollout.</p>
+                </article>
+            </div>
+        </section>
+    </main>
+
+    <footer class="site-footer">
+        <p>&copy; <span id="current-year"></span> AWARENET. All rights reserved.</p>
+    </footer>
+
+    <script src="assets/js/main.js"></script>
+</body>
+</html>

--- a/team.html
+++ b/team.html
@@ -1,0 +1,113 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Team | AWARENET</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;500;600;700&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="assets/css/styles.css">
+</head>
+<body>
+    <header class="site-header">
+        <nav class="navbar">
+            <a class="navbar__brand" href="index.html" aria-label="AWARENET">
+                <img src="assets/images/logo.svg" alt="AWARENET logo" class="navbar__logo">
+                <span class="navbar__title">AWARENET</span>
+            </a>
+            <button class="navbar__toggle" aria-expanded="false" aria-controls="primary-navigation">☰</button>
+            <ul id="primary-navigation" class="navbar__menu">
+                <li class="navbar__item"><a href="index.html" class="navbar__link">Home</a></li>
+                <li class="navbar__item"><a href="research.html" class="navbar__link">Research</a></li>
+                <li class="navbar__item"><a href="team.html" class="navbar__link navbar__link--active">Team</a></li>
+                <li class="navbar__item"><a href="news.html" class="navbar__link">News</a></li>
+                <li class="navbar__item"><a href="contact.html" class="navbar__link">Contact</a></li>
+            </ul>
+        </nav>
+    </header>
+
+    <main>
+        <section class="section section--hero" aria-labelledby="team-hero-title">
+            <div class="section__content">
+                <h1 id="team-hero-title">A network of professionals united by responsible innovation</h1>
+                <p>Researchers, entrepreneurs, and policy-makers collaborate within AWARENET to translate scientific breakthroughs into transformative products.</p>
+                <a class="button" href="contact.html">Join the network</a>
+            </div>
+            <aside class="hero-highlight" aria-label="Team snapshot">
+                <p><strong>Community:</strong> 150+ members across academia and industry</p>
+                <p><strong>Locations:</strong> Padova, Milano, Trento, and Bologna</p>
+            </aside>
+        </section>
+
+        <section class="section section--surface" aria-labelledby="team-timeline">
+            <div class="section__heading">
+                <h2 id="team-timeline">Milestones</h2>
+                <p>The network continues to grow by involving new partners and supporting community-led projects.</p>
+            </div>
+            <div class="timeline" aria-label="Network history">
+                <div class="timeline__event">
+                    <span class="timeline__year">2019</span>
+                    <p>AWARENET is founded with the goal of connecting Italian excellence in responsible research.</p>
+                </div>
+                <div class="timeline__event">
+                    <span class="timeline__year">2021</span>
+                    <p>Launch of the first joint labs with public entities and companies for interpretable AI pilot projects.</p>
+                </div>
+                <div class="timeline__event">
+                    <span class="timeline__year">2023</span>
+                    <p>Start of a mentoring program for early-stage startups developing ethical AI solutions.</p>
+                </div>
+            </div>
+        </section>
+
+        <section class="section section--muted" aria-labelledby="team-expertise">
+            <div class="section__heading">
+                <h2 id="team-expertise">Expertise areas</h2>
+                <p>Multidisciplinary expertise ensures that technological advances remain aligned with human values.</p>
+            </div>
+            <div class="card-grid">
+                <article class="card">
+                    <h3>Neuroscience &amp; cognition</h3>
+                    <p>Scholars explore neural signatures of awareness to inform explainable machine learning architectures.</p>
+                </article>
+                <article class="card">
+                    <h3>Ethics &amp; law</h3>
+                    <p>Legal experts translate regulatory requirements into governance frameworks for AI development teams.</p>
+                </article>
+                <article class="card">
+                    <h3>Engineering &amp; product</h3>
+                    <p>Technical leaders develop deployable tools and evaluate their performance in mission-critical settings.</p>
+                </article>
+            </div>
+        </section>
+
+        <section class="section section--surface" aria-labelledby="team-collaboration">
+            <div class="section__heading">
+                <h2 id="team-collaboration">How we collaborate</h2>
+                <p>Community activities create a space to experiment with new ideas and to mentor emerging talent.</p>
+            </div>
+            <div class="news-grid">
+                <article class="news-item">
+                    <h3>Residency program</h3>
+                    <p>Teams spend up to three months on-site to co-create prototypes with support from dedicated mentors.</p>
+                </article>
+                <article class="news-item">
+                    <h3>Learning circles</h3>
+                    <p>Monthly sessions feature case studies from members who apply responsible AI practices in production.</p>
+                </article>
+                <article class="news-item">
+                    <h3>Innovation grants</h3>
+                    <p>Seed funding is allocated to early-stage initiatives that promise measurable social and economic impact.</p>
+                </article>
+            </div>
+        </section>
+    </main>
+
+    <footer class="site-footer">
+        <p>&copy; <span id="current-year"></span> AWARENET. All rights reserved.</p>
+    </footer>
+
+    <script src="assets/js/main.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- replace single-page anchors with dedicated Home, Research, Team, News, and Contact pages that share a consistent header and footer
- adjust shared styles for flexible wide-screen layouts and add active navigation styling
- centralize navigation scripting in a reusable JavaScript file

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68dfe9b1883c832bb8fc9bd68bdbb92e