### PR TITLE
Adjust section backgrounds and enlarge navbar branding

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -68,12 +68,12 @@ a:focus {
     align-items: center;
     gap: 0.75rem;
     font-weight: 600;
-    font-size: 1.1rem;
+    font-size: 1.35rem;
     color: var(--color-primary);
 }
 
 .navbar__logo {
-    width: 44px;
+    width: 56px;
     height: auto;
 }
 
@@ -150,15 +150,10 @@ a:focus {
 }
 
 .section--surface {
-    background: var(--color-surface);
-    border-radius: 24px;
-    box-shadow: var(--shadow-sm);
     padding: 5rem clamp(1.25rem, 4vw, 3rem);
 }
 
 .section--muted {
-    background: linear-gradient(140deg, rgba(111, 123, 220, 0.15), rgba(79, 118, 204, 0.08));
-    border-radius: 24px;
     padding: 5rem clamp(1.25rem, 4vw, 3rem);
 }
 
@@ -168,14 +163,9 @@ a:focus {
     gap: 2.5rem;
     align-items: center;
     padding: 6rem 1.5rem 5rem;
-    background: radial-gradient(circle at 18% 22%, rgba(111, 123, 220, 0.22), transparent 55%),
-        radial-gradient(circle at 80% -5%, rgba(241, 199, 175, 0.28), transparent 45%),
-        radial-gradient(circle at 50% 120%, rgba(79, 118, 204, 0.18), transparent 55%),
-        var(--color-surface);
+    background: var(--color-background);
     width: min(1200px, 92vw);
     margin: 0 auto;
-    box-shadow: var(--shadow-sm);
-    border-radius: 24px;
 }
 
 .section--hero h1 {


### PR DESCRIPTION
## Summary
- remove contrasting backgrounds from content sections so each page shares a single backdrop
- enlarge the navbar logo and wordmark for improved brand visibility

## Testing
- not run (static content)


------
https://chatgpt.com/codex/tasks/task_e_68e138221810832bb60bceef26c5f9b0