### PR TITLE
Adjust hero layout spacing

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -12,6 +12,9 @@ html {
     --color-accent: #f1c7af;
     --font-family: 'Montserrat', sans-serif;
     --shadow-sm: 0 4px 12px rgba(16, 24, 40, 0.08);
+    --header-height: 72px;
+    --hero-top-spacing: clamp(2rem, 6vh, 3.5rem);
+    --hero-bottom-spacing: clamp(3rem, 8vh, 5rem);
 }
 
 * {
@@ -162,10 +165,13 @@ a:focus {
     grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
     gap: 2.5rem;
     align-items: center;
-    padding: 6rem 1.5rem 5rem;
+    align-content: center;
+    padding: var(--hero-top-spacing) 1.5rem var(--hero-bottom-spacing);
     background: var(--color-background);
     width: min(1200px, 92vw);
     margin: 0 auto;
+    min-height: calc(100vh - var(--header-height));
+    box-sizing: border-box;
 }
 
 .section--hero h1 {
@@ -393,7 +399,7 @@ main {
     flex: 1;
     display: grid;
     gap: clamp(3rem, 6vw, 4.5rem);
-    padding: clamp(2rem, 6vw, 4rem) 0;
+    padding: clamp(1rem, 3vh, 1.75rem) 0 clamp(3rem, 6vw, 4rem);
 }
 
 @media (max-width: 820px) {


### PR DESCRIPTION
## Summary
- introduce CSS variables to control hero spacing and header offset
- reduce main top padding and center hero content vertically across pages
- ensure hero sections fill the viewport without placing copy too low

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e139ff5c04832b875157d8543e6212