### PR TITLE
Adjust hero padding to keep hero copy in view

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -162,7 +162,7 @@ a:focus {
     grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
     gap: 2.5rem;
     align-items: center;
-    padding: 6rem 1.5rem 5rem;
+    padding: clamp(2.75rem, 11vh, 4.5rem) 1.5rem clamp(2.5rem, 9vh, 4rem);
     background: var(--color-background);
     width: min(1200px, 92vw);
     margin: 0 auto;


### PR DESCRIPTION
## Summary
- reduce hero section padding using viewport-based clamps so primary copy stays visible on initial load across pages

## Testing
- manually viewed the updated pages in the browser

------
https://chatgpt.com/codex/tasks/task_e_68e139ff5c04832b875157d8543e6212