### PR TITLE
Refine hero layout to keep hero copy in view

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -12,6 +12,7 @@ html {
     --color-accent: #f1c7af;
     --font-family: 'Montserrat', sans-serif;
     --shadow-sm: 0 4px 12px rgba(16, 24, 40, 0.08);
+    --header-offset: 5rem;
 }
 
 * {
@@ -160,9 +161,11 @@ a:focus {
 .section--hero {
     display: grid;
     grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
-    gap: 2.5rem;
+    gap: clamp(2rem, 4vw, 3rem);
     align-items: center;
-    padding: 6rem 1.5rem 5rem;
+    align-content: center;
+    padding: clamp(1.75rem, 7vh, 3.25rem) clamp(1.25rem, 3vw, 1.75rem);
+    min-height: calc(100vh - var(--header-offset));
     background: var(--color-background);
     width: min(1200px, 92vw);
     margin: 0 auto;


### PR DESCRIPTION
## Summary
- refine hero section spacing with viewport-aware clamps and grid alignment so the primary copy stays visible on initial load across pages
- reserve viewport height minus the header offset to keep hero content within the initial viewport

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e139ff5c04832b875157d8543e6212