### PR TITLE
Ensure hero background blends with global gradient

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -163,7 +163,6 @@ a:focus {
     gap: 2.5rem;
     align-items: center;
     padding: clamp(2.75rem, 11vh, 4.5rem) 1.5rem clamp(2.5rem, 9vh, 4rem);
-    background: var(--color-background);
     width: min(1200px, 92vw);
     margin: 0 auto;
 }


### PR DESCRIPTION
## Summary
- remove the hero section background color so it no longer appears as a separate raised panel
- allow the page-wide gradient background to remain visible across the hero area

## Testing
- no automated tests were run (static content change)


------
https://chatgpt.com/codex/tasks/task_e_68e140e0c38c832b893a5f54e4879b5f