### PR TITLE
Switch site typography to Inter

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -10,7 +10,7 @@ html {
     --color-text: #1f1f36;
     --color-muted: #5c5b78;
     --color-accent: #f1c7af;
-    --font-family: 'Montserrat', sans-serif;
+    --font-family: 'Inter', sans-serif;
     --shadow-sm: 0 4px 12px rgba(16, 24, 40, 0.08);
     --header-offset: 5rem;
 }
@@ -25,9 +25,19 @@ body {
     display: flex;
     flex-direction: column;
     font-family: var(--font-family);
+    font-weight: 400;
     color: var(--color-text);
     background: linear-gradient(180deg, #f6f5ff 0%, #f5edff 45%, #fef4ec 100%);
     line-height: 1.6;
+}
+
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+    font-weight: 600;
 }
 
 img {

--- a/contact.html
+++ b/contact.html
@@ -6,7 +6,7 @@
     <title>Contact | AWARENET</title>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;500;600;700&display=swap" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="assets/css/styles.css">
 </head>
 <body>

--- a/index.html
+++ b/index.html
@@ -6,7 +6,7 @@
     <title>AWARENET</title>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;500;600;700&display=swap" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="assets/css/styles.css">
 </head>
 <body>

--- a/news.html
+++ b/news.html
@@ -6,7 +6,7 @@
     <title>News | AWARENET</title>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;500;600;700&display=swap" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="assets/css/styles.css">
 </head>
 <body>

--- a/research.html
+++ b/research.html
@@ -6,7 +6,7 @@
     <title>Research | AWARENET</title>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;500;600;700&display=swap" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="assets/css/styles.css">
 </head>
 <body>

--- a/team.html
+++ b/team.html
@@ -6,7 +6,7 @@
     <title>Team | AWARENET</title>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;500;600;700&display=swap" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="assets/css/styles.css">
 </head>
 <body>


### PR DESCRIPTION
## Summary
- replace the Montserrat import with Inter on every page to align with the updated typography guidance
- set Inter as the global font family and define default weights for body copy and headings in the shared stylesheet

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68e3760aedec832bb08fbc24434301e3