### PR TITLE
Adjust hero heading size and add image placeholder

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -185,7 +185,7 @@ a:focus {
 }
 
 .section--hero h1 {
-    font-size: clamp(2.25rem, 5vw, 3.5rem);
+    font-size: clamp(1.9rem, 4.2vw, 3rem);
     margin-bottom: 1rem;
     color: var(--color-primary);
 }
@@ -194,6 +194,15 @@ a:focus {
     max-width: 540px;
     color: var(--color-muted);
     font-size: 1.05rem;
+}
+
+.section--hero .hero-image {
+    margin: 1.5rem 0 2rem;
+    border-radius: 12px;
+    box-shadow: var(--shadow-sm);
+    width: 100%;
+    max-width: 560px;
+    object-fit: cover;
 }
 
 @media (max-width: 900px) {

--- a/index.html
+++ b/index.html
@@ -32,6 +32,8 @@
             <div class="section__content">
                 <h1 id="home-title">Discover AWARENET: mapping the brain’s pathways to consciousness</h1>
                 <p>A multidisciplinary network dedicated to developing responsible, interpretable artificial intelligence solutions informed by cutting-edge neuroscience.</p>
+                <!-- Place the homepage hero image at assets/images/home/hero-overview.jpg -->
+                <img src="assets/images/home/hero-overview.jpg" alt="Abstract visualization of neural pathways representing the AWARENET collaboration." class="hero-image">
                 <a class="button" href="contact.html">Contact us</a>
             </div>
             <aside class="hero-highlight" aria-label="Quick contacts">


### PR DESCRIPTION
## Summary
- reduce the homepage hero title sizing for a subtler presentation
- insert markup for the hero image and document the expected asset location
- add styling for the new image container and ensure the asset directory exists in the repo

## Testing
- No tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68e386dea6a8832bac2772b6d431911c