### PR TITLE
Make hero media cover full viewport

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -163,67 +163,77 @@ a:focus {
     padding: 5rem clamp(1.25rem, 4vw, 3rem);
 }
 
+
 .section--hero {
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
-    gap: clamp(2rem, 4vw, 3rem);
-    align-items: flex-start;
-    align-content: start;
-    justify-items: start;
-    padding: clamp(3.25rem, 12vh, 6rem) clamp(1.5rem, 8vw, 6rem) clamp(3.5rem, 10vh, 5.5rem);
-    min-height: calc(100vh - var(--header-offset));
+    position: relative;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: clamp(3rem, 12vh, 6rem) clamp(1.5rem, 8vw, 6rem);
+    min-height: 100vh;
     width: 100%;
     max-width: none;
     margin: 0;
+    overflow: hidden;
+    color: white;
 }
 
-.section--hero > * {
-    align-self: flex-start;
+.section--hero::before {
+    content: "";
+    position: absolute;
+    inset: 0;
+    background: linear-gradient(135deg, rgba(16, 20, 40, 0.78) 0%, rgba(16, 20, 40, 0.35) 60%, rgba(16, 20, 40, 0.2) 100%);
+    z-index: 1;
+}
+
+.hero__inner {
+    position: relative;
+    z-index: 2;
+    width: min(1100px, 92vw);
+    display: grid;
+    gap: clamp(2rem, 3vw, 3rem);
 }
 
 .section--hero .section__content {
-    max-width: min(820px, 100%);
+    max-width: min(720px, 100%);
     justify-items: start;
 }
 
 .section--hero h1 {
-    font-size: clamp(2.1rem, 4.8vw, 3.4rem);
+    font-size: clamp(2.1rem, 4.8vw, 3.6rem);
     margin-bottom: 1rem;
-    color: var(--color-primary);
+    color: #f4f5ff;
     line-height: 1.12;
 }
 
 .section--hero p {
-    color: var(--color-muted);
-    font-size: clamp(1.05rem, 1.4vw, 1.25rem);
+    color: rgba(244, 245, 255, 0.88);
+    font-size: clamp(1.05rem, 1.4vw, 1.3rem);
     max-width: none;
 }
 
 .hero-media {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    width: 100%;
+    position: absolute;
+    inset: 0;
+    z-index: 0;
 }
 
-.hero-media img {
-    width: min(100%, 520px);
-    border-radius: 18px;
-    box-shadow: var(--shadow-sm);
+.hero-media img,
+.hero-media video {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    filter: saturate(1.1);
+    transform: scale(1.02);
 }
 
 @media (max-width: 900px) {
     .section--hero {
-        min-height: auto;
-        padding: clamp(2.75rem, 12vw, 4rem) 1.5rem clamp(3rem, 14vw, 4.75rem);
+        padding: clamp(2.75rem, 14vw, 4.5rem) clamp(1.25rem, 6vw, 2.5rem);
     }
 
-    .section--hero > * {
-        width: 100%;
-    }
-
-    .hero-media {
-        justify-content: flex-start;
+    .hero__inner {
+        width: min(95vw, 640px);
     }
 }
 

--- a/index.html
+++ b/index.html
@@ -30,12 +30,14 @@
 
     <main>
         <section class="section section--hero" aria-labelledby="home-title">
-            <div class="section__content">
-                <h1 id="home-title">Discover AWARENET: unravel how the brain sustain consciousness</h1>
-                <p>Atlasing the neural correlates of consciousness — insights from human brain recordings, stimulations, and lesions.</p>
+            <div class="hero-media" aria-hidden="true">
+                <img src="assets/images/brain_gif1.gif" alt="">
             </div>
-            <div class="hero-media">
-                <img src="assets/images/brain_gif1.gif" alt="Dynamic visualization of neural activity representing consciousness pathways">
+            <div class="hero__inner">
+                <div class="section__content">
+                    <h1 id="home-title">Discover AWARENET: unravel how the brain sustain consciousness</h1>
+                    <p>Atlasing the neural correlates of consciousness — insights from human brain recordings, stimulations, and lesions.</p>
+                </div>
             </div>
         </section>
 


### PR DESCRIPTION
## Summary
- restructure the hero section to treat the animated graphic as a full-bleed background
- add overlay and layout updates so the hero text remains legible across viewports

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e399ddd234832b95f8b684053ad96d