### PR TITLE
Remove lab tagline from navbar and center brand

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -163,11 +163,12 @@ a:focus {
     padding: 0.45rem 0.65rem 0.45rem 0.45rem;
     border-radius: 999px;
     transition: transform 0.25s ease;
+    cursor: default;
 }
 
 .navbar__brand:focus-visible,
 .navbar__brand:hover {
-    transform: translateY(-1px);
+    transform: none;
 }
 
 .navbar__crest {
@@ -191,7 +192,9 @@ a:focus {
 .navbar__identity {
     display: flex;
     flex-direction: column;
-    gap: 0.35rem;
+    gap: 0;
+    align-items: center;
+    text-align: center;
 }
 
 .navbar__eyebrow {

--- a/contact.html
+++ b/contact.html
@@ -12,13 +12,12 @@
 <body class="theme-dawn">
     <header class="site-header">
         <nav class="navbar">
-            <a class="navbar__brand" href="index.html" aria-label="AWARENET home">
+            <span class="navbar__brand" aria-label="AWARENET">
                 <span class="navbar__crest" aria-hidden="true"></span>
                 <span class="navbar__identity">
-                    <span class="navbar__eyebrow">Neuro-AI Consciousness Lab</span>
                     <span class="navbar__title">AWARE<span class="navbar__title--accent">NET</span></span>
                 </span>
-            </a>
+            </span>
             <button class="navbar__toggle" aria-expanded="false" aria-controls="primary-navigation">☰</button>
             <ul id="primary-navigation" class="navbar__menu">
                 <li class="navbar__item"><a href="index.html" class="navbar__link">Home</a></li>

--- a/index.html
+++ b/index.html
@@ -13,13 +13,12 @@
 <body class="theme-dawn">
     <header class="site-header">
         <nav class="navbar">
-            <a class="navbar__brand" href="index.html" aria-label="AWARENET home">
+            <span class="navbar__brand" aria-label="AWARENET">
                 <span class="navbar__crest" aria-hidden="true"></span>
                 <span class="navbar__identity">
-                    <span class="navbar__eyebrow">Neuro-AI Consciousness Lab</span>
                     <span class="navbar__title">AWARE<span class="navbar__title--accent">NET</span></span>
                 </span>
-            </a>
+            </span>
             <button class="navbar__toggle" aria-expanded="false" aria-controls="primary-navigation">☰</button>
             <ul id="primary-navigation" class="navbar__menu">
                 <li class="navbar__item"><a href="index.html" class="navbar__link navbar__link--active">Home</a></li>

--- a/news.html
+++ b/news.html
@@ -12,13 +12,12 @@
 <body class="theme-horizon">
     <header class="site-header">
         <nav class="navbar">
-            <a class="navbar__brand" href="index.html" aria-label="AWARENET home">
+            <span class="navbar__brand" aria-label="AWARENET">
                 <span class="navbar__crest" aria-hidden="true"></span>
                 <span class="navbar__identity">
-                    <span class="navbar__eyebrow">Neuro-AI Consciousness Lab</span>
                     <span class="navbar__title">AWARE<span class="navbar__title--accent">NET</span></span>
                 </span>
-            </a>
+            </span>
             <button class="navbar__toggle" aria-expanded="false" aria-controls="primary-navigation">☰</button>
             <ul id="primary-navigation" class="navbar__menu">
                 <li class="navbar__item"><a href="index.html" class="navbar__link">Home</a></li>

--- a/research.html
+++ b/research.html
@@ -12,13 +12,12 @@
 <body class="theme-horizon">
     <header class="site-header">
         <nav class="navbar">
-            <a class="navbar__brand" href="index.html" aria-label="AWARENET home">
+            <span class="navbar__brand" aria-label="AWARENET">
                 <span class="navbar__crest" aria-hidden="true"></span>
                 <span class="navbar__identity">
-                    <span class="navbar__eyebrow">Neuro-AI Consciousness Lab</span>
                     <span class="navbar__title">AWARE<span class="navbar__title--accent">NET</span></span>
                 </span>
-            </a>
+            </span>
             <button class="navbar__toggle" aria-expanded="false" aria-controls="primary-navigation">☰</button>
             <ul id="primary-navigation" class="navbar__menu">
                 <li class="navbar__item"><a href="index.html" class="navbar__link">Home</a></li>

--- a/team.html
+++ b/team.html
@@ -12,13 +12,12 @@
 <body class="theme-dusk">
     <header class="site-header">
         <nav class="navbar">
-            <a class="navbar__brand" href="index.html" aria-label="AWARENET home">
+            <span class="navbar__brand" aria-label="AWARENET">
                 <span class="navbar__crest" aria-hidden="true"></span>
                 <span class="navbar__identity">
-                    <span class="navbar__eyebrow">Neuro-AI Consciousness Lab</span>
                     <span class="navbar__title">AWARE<span class="navbar__title--accent">NET</span></span>
                 </span>
-            </a>
+            </span>
             <button class="navbar__toggle" aria-expanded="false" aria-controls="primary-navigation">☰</button>
             <ul id="primary-navigation" class="navbar__menu">
                 <li class="navbar__item"><a href="index.html" class="navbar__link">Home</a></li>


### PR DESCRIPTION
## Summary
- remove the "Neuro-AI Consciousness Lab" eyebrow label from the navigation brand across all pages
- restyle the navbar brand to centre the AWARENET title and make it non-interactive

## Testing
- not run (static content change)


------
https://chatgpt.com/codex/tasks/task_e_68e3d772e2b0832b89e869230f4bd02d