### PR TITLE
Update home about section content and layout

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -379,6 +379,10 @@ a:focus {
     max-width: 640px;
 }
 
+.section--about .section__heading {
+    max-width: 100%;
+}
+
 .section__heading h2 {
     margin: 0;
     font-size: clamp(1.75rem, 4vw, 2.5rem);
@@ -413,8 +417,12 @@ a:focus {
 }
 
 .card p {
-    margin: 0;
+    margin: 0 0 1.5rem;
     color: var(--color-muted);
+}
+
+.card p:last-child {
+    margin-bottom: 0;
 }
 
 .timeline {

--- a/index.html
+++ b/index.html
@@ -45,26 +45,21 @@
             </div>
         </section>
 
-        <section class="section section--surface" aria-labelledby="about-title">
+        <section class="section section--surface section--about" aria-labelledby="about-title">
             <div class="section__heading">
-                <h2 id="about-title">What we do</h2>
+                <h2 id="about-title">What is AWARENET</h2>
                 <p>AWARENET unites academic excellence and entrepreneurial drive to turn trustworthy AI into a reality.</p>
             </div>
             <div class="card-grid">
                 <article class="card" aria-labelledby="about-research">
-                    <h3 id="about-research">Interdisciplinary research</h3>
-                    <p>From explainable models to governance frameworks, we develop tools that are ready for adoption in highly regulated environments.</p>
-                    <a class="button button--secondary" href="research.html">Explore our work</a>
+                    <h3 id="about-research">What we do?</h3>
+                    <p>A single map to understand how the brain generates and organizes consciousness.</p>
+                    <a class="button button--secondary" href="research.html">Explore our Research</a>
                 </article>
                 <article class="card" aria-labelledby="about-team">
                     <h3 id="about-team">An extended network</h3>
-                    <p>Universities, startups, and institutions collaborate within AWARENET to bridge fundamental research with industrial needs.</p>
-                    <a class="button button--secondary" href="team.html">Meet the team</a>
-                </article>
-                <article class="card" aria-labelledby="about-news">
-                    <h3 id="about-news">Knowledge sharing</h3>
-                    <p>We publish reports, host workshops, and connect communities that are shaping the future of responsible artificial intelligence.</p>
-                    <a class="button button--secondary" href="news.html">Read the news</a>
+                    <p>AWARENET brings together Italy’s leading minds in systems and clinical neuroscience..</p>
+                    <a class="button button--secondary" href="team.html">Meet the Team</a>
                 </article>
             </div>
         </section>


### PR DESCRIPTION
## Summary
- rename the home "What we do" section to "What is AWARENET" and refresh the card copy
- reduce the card grid to two items with updated calls to action
- adjust section heading width and card paragraph spacing for improved layout

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e3d9cdfb80832b80647a8903ed4ade