### PR TITLE
Remove Plan Your Visit section from contact page

### DIFF
--- a/contact.html
+++ b/contact.html
@@ -81,26 +81,6 @@
             </div>
         </section>
 
-        <section class="section section--muted" aria-labelledby="contact-visit-title">
-            <div class="section__heading">
-                <h2 id="contact-visit-title">Plan your visit</h2>
-                <p>Our headquarters is located in the Padova innovation district and is easily accessible by public transport.</p>
-            </div>
-            <div class="card-grid">
-                <article class="card">
-                    <h3>By train</h3>
-                    <p>We are 10 minutes away from Padova Centrale. From the station, take tram line SIR1 to “Ponti Romani”.</p>
-                </article>
-                <article class="card">
-                    <h3>By car</h3>
-                    <p>Parking is available at the Innovation Center. Please request a visitor permit 24 hours in advance.</p>
-                </article>
-                <article class="card">
-                    <h3>Accessibility</h3>
-                    <p>The venue is equipped with step-free access, assistive listening devices, and private meeting spaces.</p>
-                </article>
-            </div>
-        </section>
     </main>
 
     <footer class="site-footer">


### PR DESCRIPTION
## Summary
- remove the Plan your visit section from the contact page for now

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e3eddf6880832b8a8f015d494f168a