### PR TITLE
Revamp contact page layout

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -387,10 +387,18 @@ a:focus {
     max-width: 100%;
 }
 
+.section__heading h1,
 .section__heading h2 {
     margin: 0;
-    font-size: clamp(1.75rem, 4vw, 2.5rem);
     color: var(--color-primary);
+}
+
+.section__heading h1 {
+    font-size: clamp(2rem, 4.5vw, 2.9rem);
+}
+
+.section__heading h2 {
+    font-size: clamp(1.75rem, 4vw, 2.5rem);
 }
 
 .section__heading p {
@@ -418,6 +426,58 @@ a:focus {
     margin-bottom: 0.75rem;
     font-size: 1.2rem;
     color: var(--color-primary);
+}
+
+.contact-page .section--surface {
+    background: var(--card-fill);
+    border: 1px solid var(--card-border);
+    border-radius: 24px;
+    box-shadow: var(--shadow-sm);
+}
+
+.contact-intro {
+    gap: clamp(2rem, 4vw, 3rem);
+}
+
+.contact-intro__heading {
+    justify-items: center;
+    text-align: center;
+    max-width: 100%;
+}
+
+.contact-info__grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    gap: clamp(1.5rem, 3vw, 2.5rem);
+}
+
+.contact-card {
+    display: grid;
+    gap: 1rem;
+    padding: clamp(1.75rem, 3vw, 2.5rem);
+    background: rgba(255, 255, 255, 0.88);
+    border: 1px solid var(--surface-border);
+    border-radius: 18px;
+    box-shadow: var(--shadow-sm);
+}
+
+.contact-card__icon {
+    width: 4rem;
+    height: 4rem;
+    border-radius: 1.5rem;
+    background: var(--gradient-button);
+    box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.55), 0 10px 20px rgba(62, 93, 150, 0.16);
+}
+
+.contact-card__title {
+    margin: 0;
+    font-size: 1.35rem;
+    color: var(--color-primary);
+}
+
+.contact-card p {
+    margin: 0;
+    color: var(--color-muted);
 }
 
 .card p {

--- a/contact.html
+++ b/contact.html
@@ -9,7 +9,7 @@
     <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;500;600;700&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="assets/css/styles.css">
 </head>
-<body class="theme-dawn">
+<body class="theme-dawn contact-page">
     <header class="site-header">
         <nav class="navbar">
             <span class="navbar__brand" aria-label="AWARENET">
@@ -30,17 +30,28 @@
     </header>
 
     <main>
-        <section class="section section--hero" aria-labelledby="contact-hero-title">
-            <div class="section__content">
-                <h1 id="contact-hero-title">Collaborate with us</h1>
-                <p>Write to us to propose new initiatives, request consulting, or join the AWARENET network.</p>
-                <a class="button" href="mailto:info@awarenet.org">Send an email</a>
+        <section class="section section--surface contact-intro" aria-labelledby="contact-intro-title">
+            <div class="section__heading contact-intro__heading">
+                <h1 id="contact-intro-title">Get in touch with AWARENET</h1>
+                <p>Select the most convenient channel to reach our team and we will follow up shortly.</p>
             </div>
-            <aside class="hero-highlight" aria-label="Main contacts">
-                <p><strong>Email:</strong> <a href="mailto:info@awarenet.org">info@awarenet.org</a></p>
-                <p><strong>Phone:</strong> <a href="tel:+390497654321">+39 049 7654321</a></p>
-                <p><strong>Address:</strong> Via dell'Innovazione 42, 35100 Padova (PD)</p>
-            </aside>
+            <div class="contact-info__grid" role="list">
+                <article class="contact-card" role="listitem">
+                    <span class="contact-card__icon" aria-hidden="true"></span>
+                    <h2 class="contact-card__title">Email</h2>
+                    <p>Write to <a href="mailto:info@awarenet.org">info@awarenet.org</a> for collaborations, partnerships, or general enquiries.</p>
+                </article>
+                <article class="contact-card" role="listitem">
+                    <span class="contact-card__icon" aria-hidden="true"></span>
+                    <h2 class="contact-card__title">Phone</h2>
+                    <p>Call us at <a href="tel:+390497654321">+39 049 7654321</a> to speak directly with a member of the coordination office.</p>
+                </article>
+                <article class="contact-card" role="listitem">
+                    <span class="contact-card__icon" aria-hidden="true"></span>
+                    <h2 class="contact-card__title">Main office</h2>
+                    <p>Visit us at Via dell'Innovazione 42, 35100 Padova (PD). Meetings are available upon appointment.</p>
+                </article>
+            </div>
         </section>
 
         <section class="section section--surface" aria-labelledby="contact-form-title">
@@ -49,16 +60,6 @@
                 <p>We will respond within two business days with next steps tailored to your request.</p>
             </div>
             <div class="contact-panel">
-                <div>
-                    <h3>Main contacts</h3>
-                    <ul class="contact-list">
-                        <li><strong>Email:</strong> <a href="mailto:info@awarenet.org">info@awarenet.org</a></li>
-                        <li><strong>Phone:</strong> <a href="tel:+390497654321">+39 049 7654321</a></li>
-                        <li><strong>Address:</strong> Via dell'Innovazione 42, 35100 Padova (PD)</li>
-                    </ul>
-                    <h3>Office hours</h3>
-                    <p>Monday to Friday, 9:00 – 18:00 CET.</p>
-                </div>
                 <form class="contact-form" aria-label="Contact form">
                     <div class="form-field">
                         <label for="contact-name">Name</label>


### PR DESCRIPTION
## Summary
- replace the hero section on the contact page with three contact information cards for email, phone, and the main office
- streamline the "Send us a message" area by keeping only the form panel
- add styles to support the new contact cards, centered introduction heading, tinted section backgrounds, and enlarged icon placeholders

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e3ed78ff70832b9b76d3cea6733278