### PR TITLE
Refresh team page with partners and member grid

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -346,6 +346,56 @@ a:focus {
     max-width: none;
 }
 
+.hero-institutions {
+    background: linear-gradient(135deg, #2c3458 0%, #4d547f 45%, #a5799e 100%);
+}
+
+.hero-institutions__layout {
+    display: grid;
+    gap: clamp(2rem, 4vw, 3.5rem);
+}
+
+.hero-institutions .section__content {
+    max-width: min(640px, 100%);
+}
+
+.hero-institutions .section__content p {
+    max-width: 560px;
+}
+
+.institutions-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    gap: clamp(1.5rem, 3vw, 2.25rem);
+}
+
+.institution-card {
+    display: grid;
+    gap: 1.1rem;
+    padding: 1.75rem;
+    border-radius: 1.5rem;
+    background: rgba(255, 255, 255, 0.12);
+    border: 1px solid rgba(255, 255, 255, 0.28);
+    box-shadow: 0 24px 45px rgba(21, 24, 46, 0.22);
+    text-align: center;
+    backdrop-filter: blur(6px);
+}
+
+.institution-card__logo {
+    width: min(180px, 100%);
+    height: 120px;
+    margin: 0 auto;
+    border-radius: 1rem;
+    border: 2px dashed rgba(255, 255, 255, 0.55);
+    background: rgba(255, 255, 255, 0.08);
+}
+
+.institution-card h3 {
+    margin: 0;
+    font-size: 1.15rem;
+    color: #f7f8ff;
+}
+
 .hero-media {
     position: absolute;
     inset: 0;
@@ -467,6 +517,101 @@ a:focus {
     border: 1px solid var(--glass-border);
     background: rgba(255, 255, 255, 0.88);
     box-shadow: var(--shadow-sm);
+}
+
+.team-section {
+    gap: 3rem;
+}
+
+.team-section .section__heading {
+    max-width: 640px;
+    margin: 0 auto;
+    text-align: center;
+}
+
+.team-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+    gap: clamp(1.75rem, 3vw, 2.75rem);
+}
+
+.team-card {
+    background: var(--color-surface);
+    border: 1px solid var(--surface-border);
+    border-radius: 1.75rem;
+    box-shadow: var(--shadow-sm);
+    overflow: hidden;
+    display: flex;
+    flex-direction: column;
+}
+
+.team-card__photo {
+    aspect-ratio: 5 / 6;
+    display: grid;
+    place-items: center;
+    background: linear-gradient(135deg, rgba(64, 89, 142, 0.18) 0%, rgba(176, 138, 165, 0.24) 100%);
+    color: var(--color-primary);
+    font-weight: 700;
+    font-size: 2.2rem;
+    letter-spacing: 0.12em;
+}
+
+.team-card__initials {
+    display: inline-block;
+}
+
+.team-card__body {
+    display: grid;
+    gap: 0.85rem;
+    padding: 1.75rem;
+    flex: 1;
+}
+
+.team-card__role {
+    margin: 0;
+    font-weight: 600;
+    color: var(--color-primary);
+}
+
+.team-card__bio {
+    margin: 0;
+    color: var(--color-muted);
+    font-size: 0.98rem;
+}
+
+.team-card__links {
+    list-style: none;
+    display: flex;
+    gap: 0.75rem;
+    padding: 0;
+    margin: 0;
+}
+
+.team-card__link {
+    position: relative;
+    display: grid;
+    place-items: center;
+    width: 2.5rem;
+    height: 2.5rem;
+    border-radius: 0.85rem;
+    border: 1px solid var(--card-border);
+    background: var(--card-fill);
+    transition: transform 0.2s ease, box-shadow 0.2s ease, border-color 0.2s ease;
+}
+
+.team-card__link::before {
+    content: attr(data-icon);
+    font-size: 0.85rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    color: var(--color-primary);
+}
+
+.team-card__link:hover,
+.team-card__link:focus-visible {
+    transform: translateY(-2px);
+    border-color: var(--color-secondary);
+    box-shadow: 0 16px 32px rgba(64, 89, 142, 0.18);
 }
 
 .news-item h3 {

--- a/team.html
+++ b/team.html
@@ -30,77 +30,151 @@
     </header>
 
     <main>
-        <section class="section section--hero" aria-labelledby="team-hero-title">
-            <div class="section__content">
-                <h1 id="team-hero-title">A network of professionals united by responsible innovation</h1>
-                <p>Researchers, entrepreneurs, and policy-makers collaborate within AWARENET to translate scientific breakthroughs into transformative products.</p>
-                <a class="button" href="contact.html">Join the network</a>
-            </div>
-            <aside class="hero-highlight" aria-label="Team snapshot">
-                <p><strong>Community:</strong> 150+ members across academia and industry</p>
-                <p><strong>Locations:</strong> Padova, Milano, Trento, and Bologna</p>
-            </aside>
-        </section>
-
-        <section class="section section--surface" aria-labelledby="team-timeline">
-            <div class="section__heading">
-                <h2 id="team-timeline">Milestones</h2>
-                <p>The network continues to grow by involving new partners and supporting community-led projects.</p>
-            </div>
-            <div class="timeline" aria-label="Network history">
-                <div class="timeline__event">
-                    <span class="timeline__year">2019</span>
-                    <p>AWARENET is founded with the goal of connecting Italian excellence in responsible research.</p>
+        <section class="section section--hero hero-institutions" aria-labelledby="institutions-title">
+            <div class="hero__inner hero-institutions__layout">
+                <div class="section__content">
+                    <h1 id="institutions-title">Partner Institutions &amp; Universities</h1>
+                    <p>We proudly collaborate with leading academic hubs that drive research, education, and innovation in neuroscience, data ethics, and responsible AI.</p>
                 </div>
-                <div class="timeline__event">
-                    <span class="timeline__year">2021</span>
-                    <p>Launch of the first joint labs with public entities and companies for interpretable AI pilot projects.</p>
-                </div>
-                <div class="timeline__event">
-                    <span class="timeline__year">2023</span>
-                    <p>Start of a mentoring program for early-stage startups developing ethical AI solutions.</p>
+                <div class="institutions-grid" aria-label="Institution partners">
+                    <article class="institution-card">
+                        <div class="institution-card__logo" aria-hidden="true"></div>
+                        <h3>Institute of Neuroscience Parma</h3>
+                    </article>
+                    <article class="institution-card">
+                        <div class="institution-card__logo" aria-hidden="true"></div>
+                        <h3>University of Milan</h3>
+                    </article>
+                    <article class="institution-card">
+                        <div class="institution-card__logo" aria-hidden="true"></div>
+                        <h3>University of Padova</h3>
+                    </article>
                 </div>
             </div>
         </section>
 
-        <section class="section section--muted" aria-labelledby="team-expertise">
+        <section class="section section--surface team-section" aria-labelledby="team-title">
             <div class="section__heading">
-                <h2 id="team-expertise">Expertise areas</h2>
-                <p>Multidisciplinary expertise ensures that technological advances remain aligned with human values.</p>
+                <h2 id="team-title">Meet our Team</h2>
+                <p>Researchers, engineers, and community builders join forces to shape transparent and human-centered technologies.</p>
             </div>
-            <div class="card-grid">
-                <article class="card">
-                    <h3>Neuroscience &amp; cognition</h3>
-                    <p>Scholars explore neural signatures of awareness to inform explainable machine learning architectures.</p>
+            <div class="team-grid">
+                <article class="team-card">
+                    <div class="team-card__photo" aria-hidden="true"><span class="team-card__initials">SB</span></div>
+                    <div class="team-card__body">
+                        <h3>Serena Bianchi</h3>
+                        <p class="team-card__role">Principal Investigator</p>
+                        <p class="team-card__bio">Coordinates cross-institutional studies on awareness-driven AI and oversees strategic partnerships.</p>
+                        <ul class="team-card__links" aria-label="Serena Bianchi social links">
+                            <li><a href="#" class="team-card__link" aria-label="LinkedIn profile" data-icon="in"></a></li>
+                            <li><a href="#" class="team-card__link" aria-label="Google Scholar profile" data-icon="gs"></a></li>
+                            <li><a href="#" class="team-card__link" aria-label="Personal website" data-icon="www"></a></li>
+                        </ul>
+                    </div>
                 </article>
-                <article class="card">
-                    <h3>Ethics &amp; law</h3>
-                    <p>Legal experts translate regulatory requirements into governance frameworks for AI development teams.</p>
+                <article class="team-card">
+                    <div class="team-card__photo" aria-hidden="true"><span class="team-card__initials">LM</span></div>
+                    <div class="team-card__body">
+                        <h3>Luca Marino</h3>
+                        <p class="team-card__role">Research Scientist</p>
+                        <p class="team-card__bio">Designs experiments that blend cognitive science with machine learning to improve interpretability.</p>
+                        <ul class="team-card__links" aria-label="Luca Marino social links">
+                            <li><a href="#" class="team-card__link" aria-label="LinkedIn profile" data-icon="in"></a></li>
+                            <li><a href="#" class="team-card__link" aria-label="GitHub profile" data-icon="gh"></a></li>
+                            <li><a href="#" class="team-card__link" aria-label="Personal website" data-icon="www"></a></li>
+                        </ul>
+                    </div>
                 </article>
-                <article class="card">
-                    <h3>Engineering &amp; product</h3>
-                    <p>Technical leaders develop deployable tools and evaluate their performance in mission-critical settings.</p>
+                <article class="team-card">
+                    <div class="team-card__photo" aria-hidden="true"><span class="team-card__initials">EC</span></div>
+                    <div class="team-card__body">
+                        <h3>Elisa Conti</h3>
+                        <p class="team-card__role">PhD Student</p>
+                        <p class="team-card__bio">Investigates neural markers that inform adaptive feedback loops for human-in-the-loop systems.</p>
+                        <ul class="team-card__links" aria-label="Elisa Conti social links">
+                            <li><a href="#" class="team-card__link" aria-label="LinkedIn profile" data-icon="in"></a></li>
+                            <li><a href="#" class="team-card__link" aria-label="Google Scholar profile" data-icon="gs"></a></li>
+                            <li><a href="#" class="team-card__link" aria-label="Personal website" data-icon="www"></a></li>
+                        </ul>
+                    </div>
                 </article>
-            </div>
-        </section>
-
-        <section class="section section--surface" aria-labelledby="team-collaboration">
-            <div class="section__heading">
-                <h2 id="team-collaboration">How we collaborate</h2>
-                <p>Community activities create a space to experiment with new ideas and to mentor emerging talent.</p>
-            </div>
-            <div class="news-grid">
-                <article class="news-item">
-                    <h3>Residency program</h3>
-                    <p>Teams spend up to three months on-site to co-create prototypes with support from dedicated mentors.</p>
+                <article class="team-card">
+                    <div class="team-card__photo" aria-hidden="true"><span class="team-card__initials">MG</span></div>
+                    <div class="team-card__body">
+                        <h3>Marco Greco</h3>
+                        <p class="team-card__role">Machine Learning Engineer</p>
+                        <p class="team-card__bio">Builds scalable pipelines that translate lab prototypes into reliable and secure applications.</p>
+                        <ul class="team-card__links" aria-label="Marco Greco social links">
+                            <li><a href="#" class="team-card__link" aria-label="LinkedIn profile" data-icon="in"></a></li>
+                            <li><a href="#" class="team-card__link" aria-label="GitHub profile" data-icon="gh"></a></li>
+                            <li><a href="#" class="team-card__link" aria-label="Personal website" data-icon="www"></a></li>
+                        </ul>
+                    </div>
                 </article>
-                <article class="news-item">
-                    <h3>Learning circles</h3>
-                    <p>Monthly sessions feature case studies from members who apply responsible AI practices in production.</p>
+                <article class="team-card">
+                    <div class="team-card__photo" aria-hidden="true"><span class="team-card__initials">GF</span></div>
+                    <div class="team-card__body">
+                        <h3>Giulia Ferraro</h3>
+                        <p class="team-card__role">Postdoctoral Fellow</p>
+                        <p class="team-card__bio">Explores ethical AI frameworks that align regulatory requirements with technical implementation.</p>
+                        <ul class="team-card__links" aria-label="Giulia Ferraro social links">
+                            <li><a href="#" class="team-card__link" aria-label="LinkedIn profile" data-icon="in"></a></li>
+                            <li><a href="#" class="team-card__link" aria-label="Google Scholar profile" data-icon="gs"></a></li>
+                            <li><a href="#" class="team-card__link" aria-label="Personal website" data-icon="www"></a></li>
+                        </ul>
+                    </div>
                 </article>
-                <article class="news-item">
-                    <h3>Innovation grants</h3>
-                    <p>Seed funding is allocated to early-stage initiatives that promise measurable social and economic impact.</p>
+                <article class="team-card">
+                    <div class="team-card__photo" aria-hidden="true"><span class="team-card__initials">AR</span></div>
+                    <div class="team-card__body">
+                        <h3>Andrea Rinaldi</h3>
+                        <p class="team-card__role">Cognitive Scientist</p>
+                        <p class="team-card__bio">Leads behavioural studies to ensure emerging interfaces remain accessible and inclusive for all users.</p>
+                        <ul class="team-card__links" aria-label="Andrea Rinaldi social links">
+                            <li><a href="#" class="team-card__link" aria-label="LinkedIn profile" data-icon="in"></a></li>
+                            <li><a href="#" class="team-card__link" aria-label="Google Scholar profile" data-icon="gs"></a></li>
+                            <li><a href="#" class="team-card__link" aria-label="Personal website" data-icon="www"></a></li>
+                        </ul>
+                    </div>
+                </article>
+                <article class="team-card">
+                    <div class="team-card__photo" aria-hidden="true"><span class="team-card__initials">SL</span></div>
+                    <div class="team-card__body">
+                        <h3>Sofia Lombardi</h3>
+                        <p class="team-card__role">Data Curator</p>
+                        <p class="team-card__bio">Guides data governance practices and maintains high-quality datasets for collaborative projects.</p>
+                        <ul class="team-card__links" aria-label="Sofia Lombardi social links">
+                            <li><a href="#" class="team-card__link" aria-label="LinkedIn profile" data-icon="in"></a></li>
+                            <li><a href="#" class="team-card__link" aria-label="GitHub profile" data-icon="gh"></a></li>
+                            <li><a href="#" class="team-card__link" aria-label="Personal website" data-icon="www"></a></li>
+                        </ul>
+                    </div>
+                </article>
+                <article class="team-card">
+                    <div class="team-card__photo" aria-hidden="true"><span class="team-card__initials">MR</span></div>
+                    <div class="team-card__body">
+                        <h3>Matteo Ricci</h3>
+                        <p class="team-card__role">Software Architect</p>
+                        <p class="team-card__bio">Designs resilient infrastructures that enable privacy-aware experimentation and deployment.</p>
+                        <ul class="team-card__links" aria-label="Matteo Ricci social links">
+                            <li><a href="#" class="team-card__link" aria-label="LinkedIn profile" data-icon="in"></a></li>
+                            <li><a href="#" class="team-card__link" aria-label="GitHub profile" data-icon="gh"></a></li>
+                            <li><a href="#" class="team-card__link" aria-label="Personal website" data-icon="www"></a></li>
+                        </ul>
+                    </div>
+                </article>
+                <article class="team-card">
+                    <div class="team-card__photo" aria-hidden="true"><span class="team-card__initials">CB</span></div>
+                    <div class="team-card__body">
+                        <h3>Chiara Bellini</h3>
+                        <p class="team-card__role">Community Manager</p>
+                        <p class="team-card__bio">Cultivates collaborations, organizes events, and amplifies the impact of the AWARENET network.</p>
+                        <ul class="team-card__links" aria-label="Chiara Bellini social links">
+                            <li><a href="#" class="team-card__link" aria-label="LinkedIn profile" data-icon="in"></a></li>
+                            <li><a href="#" class="team-card__link" aria-label="Google Scholar profile" data-icon="gs"></a></li>
+                            <li><a href="#" class="team-card__link" aria-label="Personal website" data-icon="www"></a></li>
+                        </ul>
+                    </div>
                 </article>
             </div>
         </section>


### PR DESCRIPTION
## Summary
- redesign the team page hero with a partners focus and institution tiles
- add a responsive 3x3 team member grid with placeholder social badges that match the site style
- extend the stylesheet with new hero, institution, and team card styles to support the refreshed layout

## Testing
- Not run (static content changes)

------
https://chatgpt.com/codex/tasks/task_e_68e3f4236e3c832b80cfbebe3460d26d