### PR TITLE
Add research objectives panel to research page

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -399,6 +399,87 @@ a:focus {
     font-size: 1.05rem;
 }
 
+.objectives-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+    gap: clamp(1.5rem, 3vw, 2.75rem);
+}
+
+.objective-card {
+    position: relative;
+    display: grid;
+    grid-template-columns: auto 1fr;
+    gap: 1.25rem;
+    align-items: start;
+    padding: clamp(1.5rem, 3vw, 2rem);
+    border-radius: 20px;
+    background: rgba(255, 255, 255, 0.92);
+    border: 1px solid var(--surface-border);
+    box-shadow: var(--shadow-sm);
+    overflow: hidden;
+}
+
+.objective-card::after {
+    content: "";
+    position: absolute;
+    inset: auto 0 0 0;
+    height: 6px;
+    background: linear-gradient(135deg, var(--color-primary), var(--color-secondary));
+    opacity: 0.72;
+}
+
+.objective-card__icon {
+    width: 72px;
+    height: 72px;
+    display: grid;
+    place-items: center;
+    border-radius: 18px;
+    background: rgba(218, 205, 233, 0.28);
+    border: 1px solid rgba(160, 122, 167, 0.32);
+    box-shadow: inset 0 6px 12px rgba(255, 255, 255, 0.45);
+}
+
+.objective-card__icon img {
+    width: 48px;
+    height: 48px;
+    object-fit: contain;
+    filter: drop-shadow(0 6px 10px rgba(58, 106, 155, 0.18));
+}
+
+.objective-card__content {
+    display: grid;
+    gap: 0.4rem;
+}
+
+.objective-card__title {
+    margin: 0;
+    font-size: 1.2rem;
+    color: var(--color-primary);
+}
+
+.objective-card__text {
+    margin: 0;
+    color: var(--color-muted);
+    font-size: 1rem;
+}
+
+@media (max-width: 680px) {
+    .objective-card {
+        grid-template-columns: 1fr;
+        text-align: left;
+    }
+
+    .objective-card__icon {
+        width: 64px;
+        height: 64px;
+    }
+
+    .objective-card__icon img {
+        width: 42px;
+        height: 42px;
+    }
+}
+
 .card-grid {
     display: grid;
     grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));

--- a/research.html
+++ b/research.html
@@ -38,6 +38,45 @@
             </div>
         </section>
 
+        <section class="section section--surface" aria-labelledby="research-objectives">
+            <div class="section__heading">
+                <h2 id="research-objectives">Research objectives</h2>
+                <p>Our agenda bridges fundamental discovery with compassionate, measurable impact.</p>
+            </div>
+            <div class="objectives-grid" role="list">
+                <article class="objective-card" role="listitem" aria-labelledby="objective-neuro">
+                    <div class="objective-card__icon" aria-hidden="true">
+                        <!-- Replace the image source once uploaded to assets/images -->
+                        <img src="assets/images/objective-neuroscience.svg" alt="" loading="lazy">
+                    </div>
+                    <div class="objective-card__content">
+                        <h3 id="objective-neuro" class="objective-card__title">Decode neural signatures</h3>
+                        <p class="objective-card__text">Map markers of awareness across sleep, anesthesia, and disorders of consciousness.</p>
+                    </div>
+                </article>
+                <article class="objective-card" role="listitem" aria-labelledby="objective-care">
+                    <div class="objective-card__icon" aria-hidden="true">
+                        <!-- Replace the image source once uploaded to assets/images -->
+                        <img src="assets/images/objective-care.svg" alt="" loading="lazy">
+                    </div>
+                    <div class="objective-card__content">
+                        <h3 id="objective-care" class="objective-card__title">Strengthen clinical pathways</h3>
+                        <p class="objective-card__text">Co-design evaluation protocols with clinicians and caregivers for patient-centered decisions.</p>
+                    </div>
+                </article>
+                <article class="objective-card" role="listitem" aria-labelledby="objective-insights">
+                    <div class="objective-card__icon" aria-hidden="true">
+                        <!-- Replace the image source once uploaded to assets/images -->
+                        <img src="assets/images/objective-insights.svg" alt="" loading="lazy">
+                    </div>
+                    <div class="objective-card__content">
+                        <h3 id="objective-insights" class="objective-card__title">Quantify outcomes</h3>
+                        <p class="objective-card__text">Develop indicators that track recovery trajectories and guide responsible interventions.</p>
+                    </div>
+                </article>
+            </div>
+        </section>
+
         <section class="section section--surface" aria-labelledby="research-pillars">
             <div class="section__heading">
                 <h2 id="research-pillars">Research pillars</h2>


### PR DESCRIPTION
## Summary
- add a concise research objectives section to the research page
- introduce objective cards styled to match the site's color palette

## Testing
- No automated tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68e3f0b20448832bb5155c02a0423d67