### PR TITLE
Remove surface panels from contact page sections

### DIFF
--- a/contact.html
+++ b/contact.html
@@ -30,7 +30,7 @@
     </header>
 
     <main>
-        <section class="section section--surface contact-intro" aria-labelledby="contact-intro-title">
+        <section class="section contact-intro" aria-labelledby="contact-intro-title">
             <div class="section__heading contact-intro__heading">
                 <h1 id="contact-intro-title">Get in touch with AWARENET</h1>
                 <p>Select the most convenient channel to reach our team and we will follow up shortly.</p>
@@ -54,7 +54,7 @@
             </div>
         </section>
 
-        <section class="section section--surface" aria-labelledby="contact-form-title">
+        <section class="section" aria-labelledby="contact-form-title">
             <div class="section__heading">
                 <h2 id="contact-form-title">Send us a message</h2>
                 <p>We will respond within two business days with next steps tailored to your request.</p>


### PR DESCRIPTION
## Summary
- remove the surface section wrapper from the contact intro and form blocks so the page inherits the global gradient background

## Testing
- no automated tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68e3f4a34718832b8a6cc1aa3a7a646b