### PR TITLE
Refactor news page with highlight and archive layouts

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -377,6 +377,10 @@ a:focus {
     max-width: 540px;
 }
 
+.section__content--narrow {
+    max-width: min(720px, 92vw);
+}
+
 .section__heading {
     display: grid;
     gap: 0.75rem;
@@ -457,6 +461,179 @@ a:focus {
     display: grid;
     grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
     gap: clamp(1.5rem, 3vw, 2.5rem);
+}
+
+.highlights {
+    padding-top: clamp(4rem, 6vw, 5rem);
+}
+
+.highlights-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+    gap: clamp(1.5rem, 3vw, 2.5rem);
+    align-items: stretch;
+}
+
+.highlight-card {
+    display: grid;
+    gap: 1.25rem;
+    background: rgba(255, 255, 255, 0.92);
+    border: 1px solid var(--card-border);
+    border-radius: 20px;
+    overflow: hidden;
+    box-shadow: var(--shadow-sm);
+}
+
+.highlight-card__media {
+    background: linear-gradient(135deg, rgba(58, 104, 153, 0.35), rgba(160, 122, 167, 0.5));
+    aspect-ratio: 4 / 3;
+}
+
+.highlight-card__body {
+    display: grid;
+    gap: 0.65rem;
+    padding: 0 1.75rem 1.75rem;
+}
+
+.highlight-card__title {
+    margin: 0;
+    font-size: 1.25rem;
+    color: var(--color-primary);
+}
+
+.highlight-card__title a {
+    color: inherit;
+}
+
+.highlight-card__title a:hover,
+.highlight-card__title a:focus {
+    color: var(--color-secondary);
+}
+
+.highlight-card__date {
+    margin: 0;
+    color: var(--color-muted);
+    font-weight: 500;
+}
+
+.news-archive__accordion {
+    display: grid;
+    gap: 1.75rem;
+}
+
+.news-year {
+    border-radius: 22px;
+    border: 1px solid var(--surface-border);
+    background: rgba(255, 255, 255, 0.9);
+    box-shadow: var(--shadow-sm);
+    overflow: hidden;
+}
+
+.news-year summary {
+    list-style: none;
+    cursor: pointer;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1rem;
+    padding: 1.5rem 1.75rem;
+    font-weight: 600;
+    color: var(--color-primary);
+}
+
+.news-year__label {
+    font-size: 1.1rem;
+    letter-spacing: 0.02em;
+}
+
+.news-year summary::-webkit-details-marker {
+    display: none;
+}
+
+.news-year summary::after {
+    content: "\25BC";
+    font-size: 0.95rem;
+    transition: transform 0.2s ease;
+}
+
+.news-year[open] summary::after {
+    transform: rotate(180deg);
+}
+
+.news-year__grid {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(240px, 1fr));
+    gap: 1.5rem;
+    padding: 0 1.75rem 1.75rem;
+}
+
+.news-card {
+    display: grid;
+    gap: 0.75rem;
+    padding: 1.5rem;
+    background: rgba(245, 246, 255, 0.9);
+    border: 1px solid var(--card-border);
+    border-radius: 18px;
+    box-shadow: var(--shadow-sm);
+}
+
+.news-card__title {
+    margin: 0;
+    font-size: 1.15rem;
+    color: var(--color-primary);
+}
+
+.news-card__title a {
+    color: inherit;
+}
+
+.news-card__title a:hover,
+.news-card__title a:focus {
+    color: var(--color-secondary);
+}
+
+.news-card__date {
+    margin: 0;
+    color: var(--color-muted);
+    font-weight: 500;
+}
+
+.news-card__date--upcoming {
+    color: var(--color-primary);
+}
+
+.news-card__description {
+    margin: 0;
+    color: var(--color-text);
+}
+
+.event-detail__back {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+    font-weight: 600;
+    color: var(--color-primary);
+}
+
+.event-detail__back::before {
+    content: "\2190";
+    font-size: 0.95rem;
+}
+
+.event-detail__back:hover,
+.event-detail__back:focus {
+    color: var(--color-secondary);
+}
+
+.event-detail__placeholder {
+    margin: 0;
+    color: var(--color-muted);
+}
+
+@media (max-width: 960px) {
+    .news-year__grid {
+        grid-template-columns: minmax(240px, 1fr);
+    }
 }
 
 .news-item {

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -21,4 +21,18 @@ document.addEventListener('DOMContentLoaded', () => {
     if (yearElement) {
         yearElement.textContent = new Date().getFullYear();
     }
+
+    const eventTitleTarget = document.querySelector('[data-event-title]');
+    if (eventTitleTarget) {
+        const params = new URLSearchParams(window.location.search);
+        const rawTitle = params.get('title');
+
+        if (rawTitle) {
+            const cleanedTitle = rawTitle.trim();
+            if (cleanedTitle.length > 0) {
+                eventTitleTarget.textContent = cleanedTitle;
+                document.title = `${cleanedTitle} | AWARENET`;
+            }
+        }
+    }
 });

--- a/event.html
+++ b/event.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Evento | AWARENET</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;500;600;700&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="assets/css/styles.css">
+</head>
+<body class="theme-horizon">
+    <header class="site-header">
+        <nav class="navbar">
+            <span class="navbar__brand" aria-label="AWARENET">
+                <span class="navbar__crest" aria-hidden="true"></span>
+                <span class="navbar__identity">
+                    <span class="navbar__title">AWARE<span class="navbar__title--accent">NET</span></span>
+                </span>
+            </span>
+            <button class="navbar__toggle" aria-expanded="false" aria-controls="primary-navigation">☰</button>
+            <ul id="primary-navigation" class="navbar__menu">
+                <li class="navbar__item"><a href="index.html" class="navbar__link">Home</a></li>
+                <li class="navbar__item"><a href="research.html" class="navbar__link">Research</a></li>
+                <li class="navbar__item"><a href="team.html" class="navbar__link">Team</a></li>
+                <li class="navbar__item"><a href="news.html" class="navbar__link navbar__link--active">News</a></li>
+                <li class="navbar__item"><a href="contact.html" class="navbar__link">Contact</a></li>
+            </ul>
+        </nav>
+    </header>
+
+    <main>
+        <section class="section section--surface" aria-labelledby="event-title">
+            <div class="section__content section__content--narrow">
+                <a class="event-detail__back" href="news.html">Back to news</a>
+                <h1 id="event-title" data-event-title>Event details</h1>
+                <p class="event-detail__placeholder">Presto qui troverai tutte le informazioni relative a questo evento.</p>
+            </div>
+        </section>
+    </main>
+
+    <footer class="site-footer">
+        <p>&copy; <span id="current-year"></span> AWARENET. All rights reserved.</p>
+    </footer>
+
+    <script src="assets/js/main.js"></script>
+</body>
+</html>

--- a/news.html
+++ b/news.html
@@ -30,81 +30,111 @@
     </header>
 
     <main>
-        <section class="section section--hero" aria-labelledby="news-hero-title">
-            <div class="section__content">
-                <h1 id="news-hero-title">Updates, stories, and opportunities across the network</h1>
-                <p>Follow our community events, research breakthroughs, and publications to stay in the loop.</p>
-                <a class="button" href="contact.html">Share your news</a>
-            </div>
-            <aside class="hero-highlight" aria-label="News highlight">
-                <p><strong>Upcoming event:</strong> Responsible AI Summit — June 20, Padova</p>
-                <p><strong>Submission deadline:</strong> Call for workshops closes on May 15</p>
-            </aside>
-        </section>
-
-        <section class="section section--surface" aria-labelledby="news-latest">
+        <section class="section section--surface highlights" aria-labelledby="news-latest">
             <div class="section__heading">
-                <h2 id="news-latest">Latest highlights</h2>
-                <p>Discover the initiatives that our members are leading this season.</p>
+                <h1 id="news-latest">Latest highlights</h1>
+                <p>Gli appuntamenti più recenti con immagini, titoli e date sempre allineati.</p>
             </div>
-            <div class="news-grid">
-                <article class="news-item">
-                    <h3>"Responsible AI" workshop</h3>
-                    <p>A collaborative training day with universities and companies to share best practices on implementing transparent systems.</p>
-                    <a class="button button--secondary" href="contact.html">Join us</a>
+            <div class="highlights-grid" role="list">
+                <article class="highlight-card" role="listitem">
+                    <div class="highlight-card__media" aria-hidden="true"></div>
+                    <div class="highlight-card__body">
+                        <h2 class="highlight-card__title">
+                            <a href="event.html?title=Sophie%20Scott%20-%20The%20neurobiology%20of%20auditory%20processing">The neurobiology of auditory processing</a>
+                        </h2>
+                        <p class="highlight-card__date">9 October 2025</p>
+                    </div>
                 </article>
-                <article class="news-item">
-                    <h3>2024 annual report</h3>
-                    <p>Discover how AWARENET-funded projects improved decision-process traceability through explainable AI tools.</p>
-                    <a class="button button--secondary" href="contact.html">Download now</a>
+                <article class="highlight-card" role="listitem">
+                    <div class="highlight-card__media" aria-hidden="true"></div>
+                    <div class="highlight-card__body">
+                        <h2 class="highlight-card__title">
+                            <a href="event.html?title=Cristina%20Alberini%20-%20From%20bench%20to%20bedside">From bench to bedside</a>
+                        </h2>
+                        <p class="highlight-card__date">21 October 2025</p>
+                    </div>
                 </article>
-                <article class="news-item">
-                    <h3>Ethical AI residency</h3>
-                    <p>Three startups are selected for an immersive residency program focusing on regulatory readiness and accountability.</p>
-                    <a class="button button--secondary" href="contact.html">Apply today</a>
-                </article>
-            </div>
-        </section>
-
-        <section class="section section--muted" aria-labelledby="news-resources">
-            <div class="section__heading">
-                <h2 id="news-resources">Resources</h2>
-                <p>Our publications and toolkits help teams scale responsible AI practices.</p>
-            </div>
-            <div class="card-grid">
-                <article class="card">
-                    <h3>Policy playbook</h3>
-                    <p>A curated set of templates to align governance with the evolving European AI Act.</p>
-                </article>
-                <article class="card">
-                    <h3>Explainability toolbox</h3>
-                    <p>Open-source libraries for model inspection, scenario analysis, and fairness assessments.</p>
-                </article>
-                <article class="card">
-                    <h3>Community newsletter</h3>
-                    <p>Quarterly insights from partners experimenting with responsible AI in complex settings.</p>
+                <article class="highlight-card" role="listitem">
+                    <div class="highlight-card__media" aria-hidden="true"></div>
+                    <div class="highlight-card__body">
+                        <h2 class="highlight-card__title">
+                            <a href="event.html?title=Padova%20Neuroscience%20Center%20Open%20Day">Padova Neuroscience Center open day</a>
+                        </h2>
+                        <p class="highlight-card__date">12 November 2025</p>
+                    </div>
                 </article>
             </div>
         </section>
 
-        <section class="section section--surface" aria-labelledby="news-participate">
+        <section class="section section--muted news-archive" aria-labelledby="news-archive-heading">
             <div class="section__heading">
-                <h2 id="news-participate">Participate</h2>
-                <p>We welcome contributions from practitioners, policy-makers, and students.</p>
+                <h2 id="news-archive-heading">All News and Events</h2>
+                <p>Consulta gli eventi passati e futuri organizzati per anno.</p>
             </div>
-            <div class="news-grid">
-                <article class="news-item">
-                    <h3>Call for speakers</h3>
-                    <p>Submit case studies, research talks, or live demos to feature in our community gatherings.</p>
-                </article>
-                <article class="news-item">
-                    <h3>Volunteer with us</h3>
-                    <p>Support outreach programs that bring responsible AI literacy to local schools and civic groups.</p>
-                </article>
-                <article class="news-item">
-                    <h3>Partner spotlights</h3>
-                    <p>Tell us about your latest achievements to be featured in the AWARENET spotlight series.</p>
-                </article>
+            <div class="news-archive__accordion">
+                <details class="news-year" open>
+                    <summary>
+                        <span class="news-year__label">2025</span>
+                    </summary>
+                    <div class="news-year__grid">
+                        <article class="news-card">
+                            <h3 class="news-card__title">
+                                <a href="event.html?title=Sophie%20Scott%20-%20The%20neurobiology%20of%20auditory%20processing">The neurobiology of auditory processing</a>
+                            </h3>
+                            <p class="news-card__date news-card__date--upcoming"><strong>9 October 2025</strong></p>
+                            <p class="news-card__description">Lecture con Sophie Scott (University College London) dedicata all'elaborazione dei suoni.</p>
+                        </article>
+                        <article class="news-card">
+                            <h3 class="news-card__title">
+                                <a href="event.html?title=Cristina%20Alberini%20-%20From%20bench%20to%20bedside">From bench to bedside</a>
+                            </h3>
+                            <p class="news-card__date news-card__date--upcoming"><strong>21 October 2025</strong></p>
+                            <p class="news-card__description">Seminario con Cristina Alberini (New York University) sulle applicazioni cliniche delle neuroscienze.</p>
+                        </article>
+                        <article class="news-card">
+                            <h3 class="news-card__title">
+                                <a href="event.html?title=Padova%20Neuroscience%20Center%20Open%20Day">Padova Neuroscience Center open day</a>
+                            </h3>
+                            <p class="news-card__date news-card__date--upcoming"><strong>12 November 2025</strong></p>
+                            <p class="news-card__description">Porte aperte ai laboratori con visite guidate e sessioni Q&amp;A con i ricercatori.</p>
+                        </article>
+                        <article class="news-card">
+                            <h3 class="news-card__title">
+                                <a href="event.html?title=NeuroAI%20Innovation%20Forum">NeuroAI Innovation Forum</a>
+                            </h3>
+                            <p class="news-card__date">17 June 2025</p>
+                            <p class="news-card__description">Forum interdisciplinare su intelligenza artificiale responsabile e neuroscienze.</p>
+                        </article>
+                    </div>
+                </details>
+                <details class="news-year">
+                    <summary>
+                        <span class="news-year__label">2024</span>
+                    </summary>
+                    <div class="news-year__grid">
+                        <article class="news-card">
+                            <h3 class="news-card__title">
+                                <a href="event.html?title=Brain%20Imaging%20Hackathon">Brain Imaging Hackathon</a>
+                            </h3>
+                            <p class="news-card__date">6 December 2024</p>
+                            <p class="news-card__description">Due giorni di lavoro intensivo su dataset aperti di neuroimaging.</p>
+                        </article>
+                        <article class="news-card">
+                            <h3 class="news-card__title">
+                                <a href="event.html?title=Neuromodulation%20Summer%20School">Neuromodulation Summer School</a>
+                            </h3>
+                            <p class="news-card__date">19 July 2024</p>
+                            <p class="news-card__description">Programma intensivo dedicato a studenti e dottorandi sulle nuove tecniche di neuromodulazione.</p>
+                        </article>
+                        <article class="news-card">
+                            <h3 class="news-card__title">
+                                <a href="event.html?title=Publication%20-%20Synaptic%20Plasticity%20Review">Publication: Synaptic Plasticity Review</a>
+                            </h3>
+                            <p class="news-card__date">10 May 2024</p>
+                            <p class="news-card__description">Il gruppo AWARENET pubblica una rassegna sulla plasticità sinaptica nelle riviste open access.</p>
+                        </article>
+                    </div>
+                </details>
             </div>
         </section>
     </main>


### PR DESCRIPTION
## Summary
- replace the news landing hero with a Latest highlights grid that supports up to three feature cards
- introduce an accordion archive organised by year with two-column layouts and bold styling for upcoming events
- add an event detail placeholder page and script to reflect the selected event title

## Testing
- No automated tests were run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68e3f058dd28832ba80badda587e9a8f