### PR TITLE
Adjust contact headings and icons

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -334,7 +334,7 @@ a:focus {
 }
 
 .section--hero h1 {
-    font-size: clamp(2.1rem, 4.8vw, 3.6rem);
+    font-size: clamp(1.93rem, 4.5vw, 3.43rem);
     margin-bottom: 1rem;
     color: #f4f5ff;
     line-height: 1.12;
@@ -448,7 +448,7 @@ a:focus {
 }
 
 .section__heading h1 {
-    font-size: clamp(2rem, 4.5vw, 2.9rem);
+    font-size: clamp(1.83rem, 4.2vw, 2.73rem);
 }
 
 .section__heading h2 {
@@ -582,14 +582,14 @@ a:focus {
 
 .contact-info__grid {
     display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
-    gap: clamp(1.5rem, 3vw, 2.5rem);
+    grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+    gap: clamp(1.25rem, 2.5vw, 2.25rem);
 }
 
 .contact-card {
     display: grid;
-    gap: 1rem;
-    padding: clamp(1.75rem, 3vw, 2.5rem);
+    gap: 0.85rem;
+    padding: clamp(1.5rem, 2.5vw, 2.2rem);
     background: rgba(255, 255, 255, 0.88);
     border: 1px solid var(--surface-border);
     border-radius: 18px;
@@ -597,22 +597,30 @@ a:focus {
 }
 
 .contact-card__icon {
-    width: 4rem;
-    height: 4rem;
-    border-radius: 1.5rem;
+    display: grid;
+    place-items: center;
+    width: 3.5rem;
+    height: 3.5rem;
+    border-radius: 1.25rem;
     background: var(--gradient-button);
     box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.55), 0 10px 20px rgba(62, 93, 150, 0.16);
 }
 
+.contact-card__icon img {
+    width: 1.9rem;
+    height: 1.9rem;
+}
+
 .contact-card__title {
     margin: 0;
-    font-size: 1.35rem;
+    font-size: 1.2rem;
     color: var(--color-primary);
 }
 
 .contact-card p {
     margin: 0;
     color: var(--color-muted);
+    font-size: 0.98rem;
 }
 
 .card p {

--- a/assets/images/icons/email.svg
+++ b/assets/images/icons/email.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" fill="none">
+  <rect width="64" height="64" rx="12" fill="url(#grad)" opacity="0.18"/>
+  <path d="M14 20h36a2 2 0 0 1 2 2v20a2 2 0 0 1-2 2H14a2 2 0 0 1-2-2V22a2 2 0 0 1 2-2Z" stroke="#2E3A67" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>
+  <path d="M12.5 22.5 32 36l19.5-13.5" stroke="#2E3A67" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>
+  <defs>
+    <linearGradient id="grad" x1="10" y1="8" x2="54" y2="56" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#E5ECFF"/>
+      <stop offset="1" stop-color="#C9D5FF"/>
+    </linearGradient>
+  </defs>
+</svg>

--- a/assets/images/icons/location.svg
+++ b/assets/images/icons/location.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" fill="none">
+  <rect width="64" height="64" rx="12" fill="url(#grad)" opacity="0.18"/>
+  <path d="M32 12c-8.3 0-15 6.6-15 14.8 0 10.6 11.4 21.6 13.9 24a1.5 1.5 0 0 0 2.1 0c2.5-2.4 13.9-13.4 13.9-24C47 18.6 40.3 12 32 12Z" stroke="#2E3A67" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="32" cy="27" r="6" stroke="#2E3A67" stroke-width="3"/>
+  <defs>
+    <linearGradient id="grad" x1="14" y1="8" x2="52" y2="56" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#E5ECFF"/>
+      <stop offset="1" stop-color="#C9D5FF"/>
+    </linearGradient>
+  </defs>
+</svg>

--- a/assets/images/icons/phone.svg
+++ b/assets/images/icons/phone.svg
@@ -1,0 +1,12 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" fill="none">
+  <rect width="64" height="64" rx="12" fill="url(#grad)" opacity="0.18"/>
+  <path d="M26.5 12h-4a4 4 0 0 0-4 4v5.6a4 4 0 0 0 .5 2l4 8a4 4 0 0 1 0 3.4l-4 8a4 4 0 0 0-.5 2V48a4 4 0 0 0 4 4h4c12.7 0 23-10.3 23-23S39.2 12 26.5 12Z" stroke="#2E3A67" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>
+  <path d="M34 20a11 11 0 0 1 10 10" stroke="#2E3A67" stroke-width="3" stroke-linecap="round"/>
+  <path d="M34 28a3 3 0 0 1 3 3" stroke="#2E3A67" stroke-width="3" stroke-linecap="round"/>
+  <defs>
+    <linearGradient id="grad" x1="12" y1="10" x2="50" y2="54" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#E5ECFF"/>
+      <stop offset="1" stop-color="#C9D5FF"/>
+    </linearGradient>
+  </defs>
+</svg>

--- a/contact.html
+++ b/contact.html
@@ -36,17 +36,23 @@
             </div>
             <div class="contact-info__grid" role="list">
                 <article class="contact-card" role="listitem">
-                    <span class="contact-card__icon" aria-hidden="true"></span>
+                    <span class="contact-card__icon" aria-hidden="true">
+                        <img src="assets/images/icons/email.svg" alt="">
+                    </span>
                     <h2 class="contact-card__title">Email</h2>
                     <p>Write to <a href="mailto:info@awarenet.org">info@awarenet.org</a> for collaborations, partnerships, or general enquiries.</p>
                 </article>
                 <article class="contact-card" role="listitem">
-                    <span class="contact-card__icon" aria-hidden="true"></span>
+                    <span class="contact-card__icon" aria-hidden="true">
+                        <img src="assets/images/icons/phone.svg" alt="">
+                    </span>
                     <h2 class="contact-card__title">Phone</h2>
                     <p>Call us at <a href="tel:+390497654321">+39 049 7654321</a> to speak directly with a member of the coordination office.</p>
                 </article>
                 <article class="contact-card" role="listitem">
-                    <span class="contact-card__icon" aria-hidden="true"></span>
+                    <span class="contact-card__icon" aria-hidden="true">
+                        <img src="assets/images/icons/location.svg" alt="">
+                    </span>
                     <h2 class="contact-card__title">Main office</h2>
                     <p>Visit us at Via dell'Innovazione 42, 35100 Padova (PD). Meetings are available upon appointment.</p>
                 </article>


### PR DESCRIPTION
## Summary
- reduce h1 typography across the site to bring titles down by roughly 2pt
- tighten the contact card layout and introduce dedicated SVG icons for each contact method

## Testing
- not run (static content changes)


------
https://chatgpt.com/codex/tasks/task_e_68e4da370c30832ba3d6d6c814f89579