### PR TITLE
Standardize section heading styling

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -441,17 +441,19 @@ a:focus {
     max-width: 100%;
 }
 
-.section__heading h1,
-.section__heading h2 {
+.section__heading > :is(h1, h2),
+.section__content > :is(h1, h2) {
     margin: 0;
     color: var(--color-primary);
 }
 
-.section__heading h1 {
+.section__heading > h1,
+.section__content > h1 {
     font-size: clamp(1.83rem, 4.2vw, 2.73rem);
 }
 
-.section__heading h2 {
+.section__heading > h2,
+.section__content > h2 {
     font-size: clamp(1.75rem, 4vw, 2.5rem);
 }
 

--- a/news.html
+++ b/news.html
@@ -32,7 +32,7 @@
     <main>
         <section class="section section--surface highlights" aria-labelledby="news-latest">
             <div class="section__heading">
-                <h1 id="news-latest">Latest highlightsx </h1>
+                <h1 id="news-latest">Latest highlights</h1>
                 <p>Gli appuntamenti più recenti con immagini, titoli e date sempre allineati.</p>
             </div>
             <div class="highlights-grid" role="list">


### PR DESCRIPTION
## Summary
- extend the shared section heading styles to cover titles rendered from section content blocks so hero headings match the rest of the site
- fix the News hero heading copy by removing the stray character from "Latest highlights"

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e4e0419e40832b91d040951c1b97db