### PR TITLE
Adjust highlights card sizing on news page

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -660,14 +660,15 @@ a:focus {
 
 .highlights-grid {
     display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
-    gap: clamp(1.5rem, 3vw, 2.5rem);
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    gap: clamp(1.25rem, 2.5vw, 2rem);
     align-items: stretch;
 }
 
 .highlight-card {
     display: grid;
-    gap: 1.25rem;
+    grid-template-rows: auto 1fr;
+    gap: 1rem;
     background: rgba(255, 255, 255, 0.92);
     border: 1px solid var(--card-border);
     border-radius: 20px;
@@ -682,8 +683,8 @@ a:focus {
 
 .highlight-card__body {
     display: grid;
-    gap: 0.65rem;
-    padding: 0 1.75rem 1.75rem;
+    gap: 0.6rem;
+    padding: 0 1.5rem 2rem;
 }
 
 .highlight-card__title {


### PR DESCRIPTION
## Summary
- reduce the minimum width of highlight cards so the latest news fits comfortably on one row
- tweak the card grid spacing and body padding to keep thumbnail area consistent while giving titles more room

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e4e148efa0832bae190a8fe3219d7b