### PR TITLE
Restore contact form size while centering panel

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -942,6 +942,17 @@ a:focus {
     color: var(--color-muted);
 }
 
+
+.contact-message-section .section__heading {
+    text-align: center;
+}
+
+.contact-message-section .contact-panel {
+    max-width: min(680px, 100%);
+    margin-inline: auto;
+    width: 100%;
+}
+
 .contact-panel {
     display: grid;
     grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));

--- a/contact.html
+++ b/contact.html
@@ -59,7 +59,7 @@
             </div>
         </section>
 
-        <section class="section" aria-labelledby="contact-form-title">
+        <section class="section contact-message-section" aria-labelledby="contact-form-title">
             <div class="section__heading">
                 <h2 id="contact-form-title">Send us a message</h2>
             </div>


### PR DESCRIPTION
## Summary
- center the "Send us a message" heading and form panel within the contact section while preserving the original form sizing

## Testing
- not run (static site)

------
https://chatgpt.com/codex/tasks/task_e_68e4de666cdc832bbb059c2230a87136