### PR TITLE
Adjust news highlights layout

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -675,7 +675,7 @@ a:focus {
 .highlight-card {
     display: grid;
     grid-template-rows: auto 1fr;
-    gap: 1rem;
+    gap: 0.85rem;
     background: rgba(255, 255, 255, 0.92);
     border: 1px solid var(--card-border);
     border-radius: 20px;
@@ -684,14 +684,14 @@ a:focus {
 }
 
 .highlight-card__media {
-    background: linear-gradient(135deg, rgba(58, 104, 153, 0.35), rgba(160, 122, 167, 0.5));
-    aspect-ratio: 4 / 3;
+    background: rgba(255, 255, 255, 0.92);
+    aspect-ratio: 3 / 2;
 }
 
 .highlight-card__body {
     display: grid;
-    gap: 0.6rem;
-    padding: 0 1.5rem 2rem;
+    gap: 0.5rem;
+    padding: 0 1.35rem 1.6rem;
 }
 
 .highlight-card__title {
@@ -752,6 +752,10 @@ a:focus {
 .news-year summary::after {
     content: "\25BC";
     font-size: 0.95rem;
+    color: var(--color-primary);
+    margin-left: 0.75rem;
+    background: transparent;
+    line-height: 1;
     transition: transform 0.2s ease;
 }
 
@@ -768,8 +772,8 @@ a:focus {
 
 .news-card {
     display: grid;
-    gap: 0.75rem;
-    padding: 1.5rem;
+    gap: 0.65rem;
+    padding: 1.35rem;
     background: rgba(245, 246, 255, 0.9);
     border: 1px solid var(--card-border);
     border-radius: 18px;


### PR DESCRIPTION
## Summary
- make the news highlight media areas share the same background as their cards
- tighten spacing inside highlight and archive cards for a more compact layout
- ensure accordion chevrons render without an extra background accent

## Testing
- no automated tests were run

------
https://chatgpt.com/codex/tasks/task_e_68e4e2c62224832b95766fb54b438b7f