### PR TITLE
Prevent wrapping in event detail view

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -806,12 +806,19 @@ a:focus {
     color: var(--color-text);
 }
 
+.event-detail {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+}
+
 .event-detail__back {
     display: inline-flex;
     align-items: center;
     gap: 0.35rem;
     font-weight: 600;
-    color: var(--color-primary);
+    color: #1f2c4d;
+    transition: color 0.2s ease;
 }
 
 .event-detail__back::before {
@@ -824,9 +831,33 @@ a:focus {
     color: var(--color-secondary);
 }
 
+.event-detail__title {
+    margin: 0;
+    max-width: 100%;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+.event-detail__image {
+    width: 100%;
+    border-radius: 18px;
+    box-shadow: var(--shadow-sm);
+}
+
 .event-detail__placeholder {
     margin: 0;
     color: var(--color-muted);
+    max-width: 100%;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+.event-detail__placeholder--wrap {
+    white-space: normal;
+    overflow: visible;
+    text-overflow: initial;
 }
 
 @media (max-width: 960px) {

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -35,4 +35,13 @@ document.addEventListener('DOMContentLoaded', () => {
             }
         }
     }
+
+    const eventDetail = document.querySelector('.event-detail');
+    if (eventDetail) {
+        const description = eventDetail.querySelector('.event-detail__placeholder');
+        if (description) {
+            const hasMedia = Boolean(eventDetail.querySelector('img, figure, picture'));
+            description.classList.toggle('event-detail__placeholder--wrap', hasMedia);
+        }
+    }
 });

--- a/event.html
+++ b/event.html
@@ -31,9 +31,10 @@
 
     <main>
         <section class="section section--surface" aria-labelledby="event-title">
-            <div class="section__content section__content--narrow">
+            <div class="section__content section__content--narrow event-detail">
                 <a class="event-detail__back" href="news.html">Back to news</a>
-                <h1 id="event-title" data-event-title>Event details</h1>
+                <h1 id="event-title" class="event-detail__title" data-event-title>Event details</h1>
+                <!-- Optional event image: add an <img> element with the class "event-detail__image" right below the title -->
                 <p class="event-detail__placeholder">Presto qui troverai tutte le informazioni relative a questo evento.</p>
             </div>
         </section>


### PR DESCRIPTION
## Summary
- add layout hooks to the event detail page so the title stays on a single line
- darken the "Back to news" link and style optional event imagery
- automatically allow the description to wrap when media is present

## Testing
- no automated tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68e4e3e8c408832b919ed920db3acf6f