### PR TITLE
Adjust team page hero styling and add asset folders

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -347,20 +347,48 @@ a:focus {
 }
 
 .hero-institutions {
-    background: linear-gradient(135deg, #2c3458 0%, #4d547f 45%, #a5799e 100%);
+    background: var(--gradient-background);
+    color: var(--color-text);
+    padding: clamp(3rem, 10vh, 5rem) clamp(1.5rem, 6vw, 4rem) clamp(3rem, 12vh, 5rem);
+    min-height: min(720px, 100vh);
+}
+
+.hero-institutions::before {
+    display: none;
 }
 
 .hero-institutions__layout {
     display: grid;
     gap: clamp(2rem, 4vw, 3.5rem);
+    align-content: center;
 }
 
 .hero-institutions .section__content {
-    max-width: min(640px, 100%);
+    max-width: none;
+    display: grid;
+    gap: 0.9rem;
+    justify-items: start;
+    overflow-x: auto;
+    padding-bottom: 0.25rem;
+    scrollbar-width: none;
+}
+
+.hero-institutions .section__content::-webkit-scrollbar {
+    display: none;
+}
+
+.hero-institutions h1 {
+    color: var(--color-primary);
+    font-size: clamp(0.65rem, calc((min(100vw, 1100px) - 4rem) / 36), 2.35rem);
+    letter-spacing: -0.01em;
+    margin-bottom: 0.5rem;
+    white-space: nowrap;
 }
 
 .hero-institutions .section__content p {
-    max-width: 560px;
+    color: var(--color-muted);
+    font-size: clamp(0.55rem, calc((min(100vw, 1100px) - 4rem) / 78), 1.1rem);
+    white-space: nowrap;
 }
 
 .institutions-grid {
@@ -371,14 +399,13 @@ a:focus {
 
 .institution-card {
     display: grid;
-    gap: 1.1rem;
-    padding: 1.75rem;
-    border-radius: 1.5rem;
-    background: rgba(255, 255, 255, 0.12);
-    border: 1px solid rgba(255, 255, 255, 0.28);
-    box-shadow: 0 24px 45px rgba(21, 24, 46, 0.22);
+    gap: 1rem;
+    padding: 1.65rem;
+    border-radius: 1.35rem;
+    background: rgba(64, 89, 142, 0.12);
+    border: 1px solid rgba(64, 89, 142, 0.16);
+    box-shadow: 0 18px 36px rgba(64, 89, 142, 0.14);
     text-align: center;
-    backdrop-filter: blur(6px);
 }
 
 .institution-card__logo {
@@ -386,14 +413,14 @@ a:focus {
     height: 120px;
     margin: 0 auto;
     border-radius: 1rem;
-    border: 2px dashed rgba(255, 255, 255, 0.55);
-    background: rgba(255, 255, 255, 0.08);
+    border: 2px dashed rgba(64, 89, 142, 0.45);
+    background: rgba(255, 255, 255, 0.8);
 }
 
 .institution-card h3 {
     margin: 0;
-    font-size: 1.15rem;
-    color: #f7f8ff;
+    font-size: 1.08rem;
+    color: var(--color-primary);
 }
 
 .hero-media {
@@ -846,40 +873,52 @@ a:focus {
 }
 
 .team-section {
-    gap: 3rem;
+    gap: 2.5rem;
 }
 
 .team-section .section__heading {
-    max-width: 640px;
-    margin: 0 auto;
-    text-align: center;
+    max-width: 720px;
+    margin: 0;
+    text-align: left;
+    display: grid;
+    gap: 0.75rem;
+    justify-items: start;
 }
 
 .team-grid {
     display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
-    gap: clamp(1.75rem, 3vw, 2.75rem);
+    grid-template-columns: repeat(auto-fit, minmax(210px, 1fr));
+    gap: clamp(1.5rem, 3vw, 2.25rem);
 }
 
 .team-card {
     background: var(--color-surface);
     border: 1px solid var(--surface-border);
-    border-radius: 1.75rem;
+    border-radius: 1.35rem;
     box-shadow: var(--shadow-sm);
     overflow: hidden;
     display: flex;
     flex-direction: column;
+    max-width: 320px;
+    margin: 0 auto;
 }
 
 .team-card__photo {
-    aspect-ratio: 5 / 6;
+    aspect-ratio: 4 / 5;
     display: grid;
     place-items: center;
-    background: linear-gradient(135deg, rgba(64, 89, 142, 0.18) 0%, rgba(176, 138, 165, 0.24) 100%);
+    background: linear-gradient(135deg, rgba(64, 89, 142, 0.16) 0%, rgba(176, 138, 165, 0.2) 100%);
     color: var(--color-primary);
     font-weight: 700;
-    font-size: 2.2rem;
-    letter-spacing: 0.12em;
+    font-size: 1.85rem;
+    letter-spacing: 0.1em;
+    overflow: hidden;
+}
+
+.team-card__photo img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
 }
 
 .team-card__initials {
@@ -888,8 +927,8 @@ a:focus {
 
 .team-card__body {
     display: grid;
-    gap: 0.85rem;
-    padding: 1.75rem;
+    gap: 0.75rem;
+    padding: 1.4rem 1.5rem 1.6rem;
     flex: 1;
 }
 

--- a/assets/icons_team/.gitkeep
+++ b/assets/icons_team/.gitkeep
@@ -1,0 +1,1 @@
+Placeholder for team member link icon assets (e.g., LinkedIn, personal sites).

--- a/assets/icons_uni/.gitkeep
+++ b/assets/icons_uni/.gitkeep
@@ -1,0 +1,1 @@
+Placeholder for partner institution and university icon files.

--- a/assets/photos_team/.gitkeep
+++ b/assets/photos_team/.gitkeep
@@ -1,0 +1,1 @@
+Placeholder for team member portrait photos.

--- a/team.html
+++ b/team.html
@@ -34,7 +34,7 @@
             <div class="hero__inner hero-institutions__layout">
                 <div class="section__content">
                     <h1 id="institutions-title">Partner Institutions &amp; Universities</h1>
-                    <p>We proudly collaborate with leading academic hubs that drive research, education, and innovation in neuroscience, data ethics, and responsible AI.</p>
+                    <p>We partner with leading universities advancing neuroscience, data ethics, and responsible AI.</p>
                 </div>
                 <div class="institutions-grid" aria-label="Institution partners">
                     <article class="institution-card">


### PR DESCRIPTION
## Summary
- update the team hero section with a lighter background, single-line copy, and refreshed institution cards
- left-align the team heading, shrink team member cards, and support optional profile photos
- add asset directories for institution icons, team icons, and team photos

## Testing
- No automated tests were run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68e4e5224fc0832ba9d63daa341fd95f