### PR TITLE
Adjust contact card spacing and icon styling

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -577,13 +577,14 @@ a:focus {
 .contact-info__grid {
     display: grid;
     grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
-    gap: clamp(1.25rem, 2.5vw, 2.25rem);
+    gap: clamp(1rem, 2vw, 1.75rem);
+    margin-block-end: clamp(2.5rem, 6vw, 4rem);
 }
 
 .contact-card {
     display: grid;
-    gap: 0.85rem;
-    padding: clamp(1.5rem, 2.5vw, 2.2rem);
+    gap: 0.65rem;
+    padding: clamp(1.1rem, 2vw, 1.85rem);
     background: rgba(255, 255, 255, 0.88);
     border: 1px solid var(--surface-border);
     border-radius: 18px;
@@ -594,20 +595,20 @@ a:focus {
     display: flex;
     align-items: center;
     justify-content: center;
-    width: min(100%, 12rem);
+    width: min(100%, 9rem);
     justify-self: center;
     aspect-ratio: 1;
     border-radius: 16px;
-    background: rgba(255, 255, 255, 0.92);
-    border: 1px solid var(--surface-border);
-    box-shadow: var(--shadow-sm);
+    background: transparent;
+    border: none;
+    box-shadow: none;
     overflow: hidden;
 }
 
 .contact-card__icon img {
-    width: clamp(3rem, 38%, 4.25rem);
-    max-width: 100%;
-    height: auto;
+    width: 100%;
+    height: 100%;
+    object-fit: contain;
 }
 
 .contact-card__title {


### PR DESCRIPTION
## Summary
- reduce the padding and spacing of the contact cards for a more compact layout with extra spacing beneath the grid
- update the icon container so custom images sit flush with the background without elevated framing

## Testing
- no automated tests were run (static CSS change)


------
https://chatgpt.com/codex/tasks/task_e_68e4e6919d88832b8c578618490b1196