### PR TITLE
Reduce section headings by 2pt

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -449,12 +449,12 @@ a:focus {
 
 .section__heading > h1,
 .section__content > h1 {
-    font-size: clamp(1.83rem, 4.2vw, 2.73rem);
+    font-size: calc(clamp(1.83rem, 4.2vw, 2.73rem) - 2pt);
 }
 
 .section__heading > h2,
 .section__content > h2 {
-    font-size: clamp(1.75rem, 4vw, 2.5rem);
+    font-size: calc(clamp(1.75rem, 4vw, 2.5rem) - 2pt);
 }
 
 .section__heading p {


### PR DESCRIPTION
## Summary
- reduce the clamp-based font sizes for section headings by subtracting 2pt so titles like "Latest highlights" appear smaller across pages

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e4e709702c832b9b742d7fed5da033