### PR TITLE
Adjust highlight card dimensions on news page

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -667,7 +667,7 @@ a:focus {
 
 .highlights-grid {
     display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+    grid-template-columns: repeat(auto-fit, minmax(190px, 1fr));
     gap: clamp(1rem, 2vw, 1.5rem);
     align-items: stretch;
 }
@@ -675,7 +675,7 @@ a:focus {
 .highlight-card {
     display: grid;
     grid-template-rows: auto 1fr;
-    gap: 0.75rem;
+    gap: 0.65rem;
     background: rgba(255, 255, 255, 0.92);
     border: 1px solid var(--card-border);
     border-radius: 18px;
@@ -685,13 +685,13 @@ a:focus {
 
 .highlight-card__media {
     background: linear-gradient(135deg, rgba(58, 104, 153, 0.35), rgba(160, 122, 167, 0.5));
-    aspect-ratio: 5 / 3;
+    aspect-ratio: 3 / 2;
 }
 
 .highlight-card__body {
     display: grid;
-    gap: 0.5rem;
-    padding: 0 1.25rem 1.5rem;
+    gap: 0.45rem;
+    padding: 0 1.1rem 1.35rem;
 }
 
 .highlight-card__title {


### PR DESCRIPTION
## Summary
- slightly reduce the highlights grid minimum column width to shrink each card
- tighten the highlight card spacing and aspect ratio so the cards appear more compact

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e4e713cb7c832b831ba18acbf1969b