### PR TITLE
Tighten news highlight card sizing

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -667,9 +667,10 @@ a:focus {
 
 .highlights-grid {
     display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+    grid-template-columns: repeat(auto-fit, minmax(0, clamp(200px, 26vw, 240px)));
     gap: clamp(1rem, 2vw, 1.5rem);
     align-items: stretch;
+    justify-content: center;
 }
 
 .highlight-card {
@@ -685,13 +686,13 @@ a:focus {
 
 .highlight-card__media {
     background: linear-gradient(135deg, rgba(58, 104, 153, 0.35), rgba(160, 122, 167, 0.5));
-    aspect-ratio: 5 / 3;
+    aspect-ratio: 4 / 3;
 }
 
 .highlight-card__body {
     display: grid;
     gap: 0.5rem;
-    padding: 0 1.25rem 1.5rem;
+    padding: 0 1.1rem 1.3rem;
 }
 
 .highlight-card__title {


### PR DESCRIPTION
## Summary
- shrink the highlight cards in the news grid with a tighter width clamp and aspect ratio
- center the grid layout and trim internal padding to keep the cards compact

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68e4e713cb7c832b831ba18acbf1969b