### PR TITLE
Adjust event detail heading sizing and wrapping

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -839,9 +839,11 @@ a:focus {
 .event-detail__title {
     margin: 0;
     max-width: 100%;
-    white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
+    font-size: clamp(1.5rem, 3.4vw, 2.15rem);
+    line-height: 1.25;
+    white-space: normal;
+    overflow: visible;
+    text-overflow: initial;
 }
 
 .event-detail__image {
@@ -854,9 +856,9 @@ a:focus {
     margin: 0;
     color: var(--color-muted);
     max-width: 100%;
-    white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
+    white-space: normal;
+    overflow: visible;
+    text-overflow: initial;
 }
 
 .event-detail__placeholder--wrap {


### PR DESCRIPTION
## Summary
- allow event detail titles and placeholder copy to wrap naturally instead of truncating with ellipses
- reduce the event detail title font size to better fit long speaker names

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68e4e7f1c9b4832b8557d33e020ebee2