### PR TITLE
Shorten contact sections and tighten form spacing

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -991,8 +991,13 @@ a:focus {
     text-align: center;
 }
 
+
+.contact-page .section {
+    padding-block: clamp(3.25rem, 10vh, 4.35rem);
+}
+
 .contact-message-section .contact-panel {
-    max-width: min(680px, 100%);
+    max-width: min(720px, 100%);
     margin-inline: auto;
     width: 100%;
 }
@@ -1018,8 +1023,8 @@ a:focus {
 
 .contact-form {
     display: grid;
-    gap: 1rem;
-    padding: 2rem;
+    gap: 0.65rem;
+    padding: 1.25rem 1.85rem;
     background: rgba(255, 255, 255, 0.85);
     border-radius: 18px;
     box-shadow: var(--shadow-sm);


### PR DESCRIPTION
## Summary
- shorten the vertical padding on contact page sections so the content sits lower on the page
- reduce internal spacing within the contact form to further shrink its height

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e4e6be85a8832ba2e75f65aaef5672