### PR TITLE
Adjust team page layout for three-column grid

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -913,7 +913,7 @@ a:focus {
 }
 
 .team-section .section__heading {
-    max-width: 720px;
+    max-width: none;
     margin: 0;
     text-align: left;
     display: grid;
@@ -921,9 +921,13 @@ a:focus {
     justify-items: start;
 }
 
+.team-section .section__heading p {
+    white-space: nowrap;
+}
+
 .team-grid {
     display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(210px, 1fr));
+    grid-template-columns: repeat(3, minmax(0, 1fr));
     gap: clamp(1.5rem, 3vw, 2.25rem);
 }
 
@@ -935,12 +939,11 @@ a:focus {
     overflow: hidden;
     display: flex;
     flex-direction: column;
-    max-width: 320px;
-    margin: 0 auto;
+    height: 100%;
 }
 
 .team-card__photo {
-    aspect-ratio: 4 / 5;
+    aspect-ratio: 4 / 3;
     display: grid;
     place-items: center;
     background: linear-gradient(135deg, rgba(64, 89, 142, 0.16) 0%, rgba(176, 138, 165, 0.2) 100%);
@@ -963,8 +966,8 @@ a:focus {
 
 .team-card__body {
     display: grid;
-    gap: 0.75rem;
-    padding: 1.4rem 1.5rem 1.6rem;
+    gap: 0.65rem;
+    padding: 1.1rem 1.3rem 1.3rem;
     flex: 1;
 }
 
@@ -1013,6 +1016,23 @@ a:focus {
     transform: translateY(-2px);
     border-color: var(--color-secondary);
     box-shadow: 0 16px 32px rgba(64, 89, 142, 0.18);
+}
+
+@media (max-width: 1024px) {
+    .team-grid {
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+    }
+
+    .team-section .section__heading p {
+        white-space: normal;
+    }
+}
+
+@media (max-width: 680px) {
+    .team-grid {
+        grid-template-columns: minmax(0, 1fr);
+    }
+
 }
 
 .news-item h3 {


### PR DESCRIPTION
## Summary
- keep the team section intro copy on a single line on large screens while letting it wrap responsively on smaller widths
- enforce a three-column layout for team members with responsive fallbacks for tablets and phones
- shorten the team member cards by shrinking the photo area and tightening spacing

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e4e93591d0832b9088dd418b98cf21