### PR TITLE
Reduce contact card icon size

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -630,7 +630,7 @@ a:focus {
     display: flex;
     align-items: center;
     justify-content: center;
-    width: min(100%, 7.5rem);
+    width: min(100%, 5.5rem);
     justify-self: center;
     aspect-ratio: 1;
     border-radius: 16px;
@@ -641,8 +641,8 @@ a:focus {
 }
 
 .contact-card__icon img {
-    width: 100%;
-    height: 100%;
+    width: 80%;
+    height: 80%;
     object-fit: contain;
 }
 


### PR DESCRIPTION
## Summary
- decrease the contact card icon container to 5.5rem to shrink the visuals
- scale the icon images to 80% of the container for better balance

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e5077780a8832bae9a3e912a95d8d1