### PR TITLE
Adjust highlight card sizing on news page

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -703,8 +703,8 @@ a:focus {
 
 .highlights-grid {
     display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(0, clamp(200px, 26vw, 240px)));
-    gap: clamp(1rem, 2vw, 1.5rem);
+    grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+    gap: clamp(1.25rem, 2.5vw, 2rem);
     align-items: stretch;
     justify-content: center;
 }
@@ -712,28 +712,29 @@ a:focus {
 .highlight-card {
     display: grid;
     grid-template-rows: auto 1fr;
-    gap: 0.65rem;
+    gap: 0.85rem;
     background: rgba(255, 255, 255, 0.92);
     border: 1px solid var(--card-border);
     border-radius: 18px;
     overflow: hidden;
     box-shadow: var(--shadow-sm);
+    min-height: clamp(300px, 32vw, 340px);
 }
 
 .highlight-card__media {
     background: linear-gradient(135deg, rgba(58, 104, 153, 0.35), rgba(160, 122, 167, 0.5));
-    aspect-ratio: 4 / 3;
+    aspect-ratio: 5 / 4;
 }
 
 .highlight-card__body {
     display: grid;
-    gap: 0.5rem;
-    padding: 0 1.1rem 1.3rem;
+    gap: 0.6rem;
+    padding: 0 1.3rem 1.55rem;
 }
 
 .highlight-card__title {
     margin: 0;
-    font-size: 1.15rem;
+    font-size: 1.2rem;
     line-height: 1.35;
     color: var(--color-primary);
 }


### PR DESCRIPTION
## Summary
- increase the minimum width of highlight cards on the news page so they align better with the section heading
- add a minimum height and larger media ratio so the cards feel more balanced with their text content
- tweak spacing inside the cards for improved readability

## Testing
- no automated tests were run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68e507c91490832b9b03decc02bb7146