### PR TITLE
Darken year and date colors

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -29,7 +29,7 @@ html {
     --crest-shadow: rgba(62, 93, 150, 0.32);
     --hero-overlay: linear-gradient(135deg, rgba(35, 44, 73, 0.78) 0%, rgba(49, 59, 92, 0.42) 60%, rgba(78, 90, 122, 0.26) 100%);
     --color-title-strong: #324d88;
-    --color-year-date: #3b2f70;
+    --color-year-date: #2a1f5a;
 }
 
 body.theme-dawn {
@@ -55,7 +55,7 @@ body.theme-dawn {
     --crest-shadow: rgba(62, 93, 150, 0.32);
     --hero-overlay: linear-gradient(135deg, rgba(35, 44, 73, 0.78) 0%, rgba(49, 59, 92, 0.42) 60%, rgba(78, 90, 122, 0.26) 100%);
     --color-title-strong: #324d88;
-    --color-year-date: #3b2f70;
+    --color-year-date: #2a1f5a;
 }
 
 body.theme-horizon {
@@ -81,7 +81,7 @@ body.theme-horizon {
     --crest-shadow: rgba(58, 104, 153, 0.3);
     --hero-overlay: linear-gradient(135deg, rgba(36, 50, 74, 0.74) 0%, rgba(52, 70, 100, 0.4) 60%, rgba(88, 105, 129, 0.24) 100%);
     --color-title-strong: #2f5a92;
-    --color-year-date: #2f3d7a;
+    --color-year-date: #1f285f;
 }
 
 body.theme-dusk {
@@ -107,7 +107,7 @@ body.theme-dusk {
     --crest-shadow: rgba(64, 89, 142, 0.32);
     --hero-overlay: linear-gradient(135deg, rgba(38, 45, 70, 0.76) 0%, rgba(56, 62, 90, 0.42) 60%, rgba(88, 92, 120, 0.24) 100%);
     --color-title-strong: #384f87;
-    --color-year-date: #3a2f6f;
+    --color-year-date: #281d56;
 }
 
 * {


### PR DESCRIPTION
## Summary
- darkened the shared year and date color variable for each theme to improve contrast

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e507ee1cf0832b922d37f36e99b9ba