### PR TITLE
Add media thumbnails to news archive cards

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -809,13 +809,41 @@ a:focus {
 }
 
 .news-card {
-    display: grid;
-    gap: 0.65rem;
-    padding: 1.35rem;
+    display: flex;
+    gap: 1rem;
+    padding: 1.2rem;
     background: rgba(245, 246, 255, 0.9);
     border: 1px solid var(--card-border);
     border-radius: 18px;
     box-shadow: var(--shadow-sm);
+    align-items: flex-start;
+}
+
+.news-card__media {
+    flex: 0 0 96px;
+    width: 96px;
+    aspect-ratio: 1 / 1;
+    border-radius: 16px;
+    overflow: hidden;
+    background: var(--card-fill);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.5);
+    margin: 0;
+}
+
+.news-card__media img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    display: block;
+}
+
+.news-card__content {
+    display: grid;
+    gap: 0.55rem;
+    flex: 1 1 auto;
 }
 
 .news-card__title {
@@ -847,6 +875,24 @@ a:focus {
 .news-card__description {
     margin: 0;
     color: var(--color-text);
+}
+
+@media (max-width: 720px) {
+    .news-card {
+        flex-direction: column;
+        align-items: stretch;
+    }
+
+    .news-card__media {
+        width: 100%;
+        max-width: 320px;
+        aspect-ratio: 4 / 3;
+        margin: 0 auto;
+    }
+
+    .news-card__content {
+        gap: 0.65rem;
+    }
 }
 
 .event-detail {

--- a/assets/images/news/auditory-processing.svg
+++ b/assets/images/news/auditory-processing.svg
@@ -1,0 +1,12 @@
+<svg width="120" height="120" viewBox="0 0 120 120" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="auditoryGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#7a8edb" />
+      <stop offset="100%" stop-color="#b98ed4" />
+    </linearGradient>
+  </defs>
+  <rect width="120" height="120" rx="22" fill="url(#auditoryGradient)" />
+  <path d="M52 36c14 0 24 10 24 24 0 4-1 8-3 11l-6 9a4 4 0 01-6 1 4 4 0 01-1-6l6-9c1-2 1-4 1-6 0-8-7-15-15-15s-15 7-15 15c0 6 3 11 9 14a4 4 0 11-3 7C34 74 29 65 29 60c0-13 10-24 23-24z" fill="#fdfcff" opacity="0.92" />
+  <circle cx="84" cy="75" r="10" fill="#fdfcff" opacity="0.65" />
+  <circle cx="92" cy="39" r="8" fill="#fdfcff" opacity="0.35" />
+</svg>

--- a/assets/images/news/brain-imaging-hackathon.svg
+++ b/assets/images/news/brain-imaging-hackathon.svg
@@ -1,0 +1,12 @@
+<svg width="120" height="120" viewBox="0 0 120 120" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="hackathonGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#5a7ccb" />
+      <stop offset="100%" stop-color="#62c7d3" />
+    </linearGradient>
+  </defs>
+  <rect width="120" height="120" rx="22" fill="url(#hackathonGradient)" />
+  <rect x="24" y="34" width="72" height="52" rx="14" fill="#fdfcff" opacity="0.88" />
+  <path d="M36 46h48v6H36zm0 16h48v6H36zm0 16h48v6H36z" fill="#5a7ccb" opacity="0.7" />
+  <circle cx="60" cy="40" r="10" fill="#fdfcff" opacity="0.5" />
+</svg>

--- a/assets/images/news/from-bench-to-bedside.svg
+++ b/assets/images/news/from-bench-to-bedside.svg
@@ -1,0 +1,13 @@
+<svg width="120" height="120" viewBox="0 0 120 120" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="benchGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#6e9fcf" />
+      <stop offset="100%" stop-color="#9d7fc0" />
+    </linearGradient>
+  </defs>
+  <rect width="120" height="120" rx="22" fill="url(#benchGradient)" />
+  <rect x="26" y="32" width="68" height="48" rx="12" fill="#ffffff" opacity="0.85" />
+  <path d="M42 48h8v24h-8zM70 48h8v24h-8z" fill="#6e9fcf" opacity="0.75" />
+  <path d="M34 78h52a6 6 0 016 6v4H28v-4a6 6 0 016-6z" fill="#ffffff" opacity="0.9" />
+  <circle cx="60" cy="40" r="10" fill="#ffffff" opacity="0.6" />
+</svg>

--- a/assets/images/news/neuroai-innovation-forum.svg
+++ b/assets/images/news/neuroai-innovation-forum.svg
@@ -1,0 +1,14 @@
+<svg width="120" height="120" viewBox="0 0 120 120" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="neuroaiGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#5d6fb8" />
+      <stop offset="100%" stop-color="#a876c5" />
+    </linearGradient>
+  </defs>
+  <rect width="120" height="120" rx="22" fill="url(#neuroaiGradient)" />
+  <path d="M60 32c10 0 18 8 18 18 0 7-4 14-10 17l4 13a4 4 0 01-3 5h-18a4 4 0 01-3-5l4-13c-6-3-10-10-10-17 0-10 8-18 18-18z" fill="#fdfcff" opacity="0.9" />
+  <circle cx="60" cy="50" r="6" fill="#5d6fb8" opacity="0.7" />
+  <path d="M50 84h20a6 6 0 016 6v4H44v-4a6 6 0 016-6z" fill="#fdfcff" opacity="0.85" />
+  <circle cx="84" cy="40" r="8" fill="#fdfcff" opacity="0.5" />
+  <circle cx="36" cy="40" r="6" fill="#fdfcff" opacity="0.35" />
+</svg>

--- a/assets/images/news/neuromodulation-summer-school.svg
+++ b/assets/images/news/neuromodulation-summer-school.svg
@@ -1,0 +1,11 @@
+<svg width="120" height="120" viewBox="0 0 120 120" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="summerGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#5f7bc3" />
+      <stop offset="100%" stop-color="#f0a864" />
+    </linearGradient>
+  </defs>
+  <rect width="120" height="120" rx="22" fill="url(#summerGradient)" />
+  <path d="M60 30l9 18 20 3-15 14 3 20-17-9-17 9 3-20-15-14 20-3z" fill="#fdfcff" opacity="0.85" />
+  <circle cx="60" cy="60" r="14" fill="#f0a864" opacity="0.6" />
+</svg>

--- a/assets/images/news/padova-neuroscience-center.svg
+++ b/assets/images/news/padova-neuroscience-center.svg
@@ -1,0 +1,14 @@
+<svg width="120" height="120" viewBox="0 0 120 120" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="padovaGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#5f88c4" />
+      <stop offset="100%" stop-color="#85c0c9" />
+    </linearGradient>
+  </defs>
+  <rect width="120" height="120" rx="22" fill="url(#padovaGradient)" />
+  <path d="M60 32c-14 0-26 10-28 24h8c2-9 10-16 20-16s18 7 20 16h8c-2-14-14-24-28-24z" fill="#fdfcff" opacity="0.9" />
+  <path d="M36 68h48v20H36z" fill="#fdfcff" opacity="0.85" />
+  <path d="M48 60h24a8 8 0 018 8v4H40v-4a8 8 0 018-8z" fill="#fdfcff" opacity="0.7" />
+  <circle cx="42" cy="46" r="6" fill="#fdfcff" opacity="0.7" />
+  <circle cx="78" cy="46" r="6" fill="#fdfcff" opacity="0.7" />
+</svg>

--- a/assets/images/news/synaptic-plasticity-review.svg
+++ b/assets/images/news/synaptic-plasticity-review.svg
@@ -1,0 +1,13 @@
+<svg width="120" height="120" viewBox="0 0 120 120" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="synapticGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#6f6fbf" />
+      <stop offset="100%" stop-color="#c17fc9" />
+    </linearGradient>
+  </defs>
+  <rect width="120" height="120" rx="22" fill="url(#synapticGradient)" />
+  <path d="M46 42a10 10 0 0120 0v36a10 10 0 01-20 0V42z" fill="#fdfcff" opacity="0.85" />
+  <path d="M74 42a10 10 0 0120 0v36a10 10 0 01-20 0V42z" fill="#fdfcff" opacity="0.7" />
+  <circle cx="56" cy="60" r="8" fill="#6f6fbf" opacity="0.6" />
+  <circle cx="84" cy="60" r="8" fill="#c17fc9" opacity="0.6" />
+</svg>

--- a/news.html
+++ b/news.html
@@ -78,32 +78,52 @@
                     </summary>
                     <div class="news-year__grid">
                         <article class="news-card">
-                            <h3 class="news-card__title">
-                                <a href="event.html?title=Sophie%20Scott%20-%20The%20neurobiology%20of%20auditory%20processing">The neurobiology of auditory processing</a>
-                            </h3>
-                            <p class="news-card__date news-card__date--upcoming"><strong>9 October 2025</strong></p>
-                            <p class="news-card__description">Lecture con Sophie Scott (University College London) dedicata all'elaborazione dei suoni.</p>
+                            <figure class="news-card__media" aria-hidden="true">
+                                <img src="assets/images/news/auditory-processing.svg" alt="" loading="lazy">
+                            </figure>
+                            <div class="news-card__content">
+                                <h3 class="news-card__title">
+                                    <a href="event.html?title=Sophie%20Scott%20-%20The%20neurobiology%20of%20auditory%20processing">The neurobiology of auditory processing</a>
+                                </h3>
+                                <p class="news-card__date news-card__date--upcoming"><strong>9 October 2025</strong></p>
+                                <p class="news-card__description">Lecture con Sophie Scott (University College London) dedicata all'elaborazione dei suoni.</p>
+                            </div>
                         </article>
                         <article class="news-card">
-                            <h3 class="news-card__title">
-                                <a href="event.html?title=Cristina%20Alberini%20-%20From%20bench%20to%20bedside">From bench to bedside</a>
-                            </h3>
-                            <p class="news-card__date news-card__date--upcoming"><strong>21 October 2025</strong></p>
-                            <p class="news-card__description">Seminario con Cristina Alberini (New York University) sulle applicazioni cliniche delle neuroscienze.</p>
+                            <figure class="news-card__media" aria-hidden="true">
+                                <img src="assets/images/news/from-bench-to-bedside.svg" alt="" loading="lazy">
+                            </figure>
+                            <div class="news-card__content">
+                                <h3 class="news-card__title">
+                                    <a href="event.html?title=Cristina%20Alberini%20-%20From%20bench%20to%20bedside">From bench to bedside</a>
+                                </h3>
+                                <p class="news-card__date news-card__date--upcoming"><strong>21 October 2025</strong></p>
+                                <p class="news-card__description">Seminario con Cristina Alberini (New York University) sulle applicazioni cliniche delle neuroscienze.</p>
+                            </div>
                         </article>
                         <article class="news-card">
-                            <h3 class="news-card__title">
-                                <a href="event.html?title=Padova%20Neuroscience%20Center%20Open%20Day">Padova Neuroscience Center open day</a>
-                            </h3>
-                            <p class="news-card__date news-card__date--upcoming"><strong>12 November 2025</strong></p>
-                            <p class="news-card__description">Porte aperte ai laboratori con visite guidate e sessioni Q&amp;A con i ricercatori.</p>
+                            <figure class="news-card__media" aria-hidden="true">
+                                <img src="assets/images/news/padova-neuroscience-center.svg" alt="" loading="lazy">
+                            </figure>
+                            <div class="news-card__content">
+                                <h3 class="news-card__title">
+                                    <a href="event.html?title=Padova%20Neuroscience%20Center%20Open%20Day">Padova Neuroscience Center open day</a>
+                                </h3>
+                                <p class="news-card__date news-card__date--upcoming"><strong>12 November 2025</strong></p>
+                                <p class="news-card__description">Porte aperte ai laboratori con visite guidate e sessioni Q&amp;A con i ricercatori.</p>
+                            </div>
                         </article>
                         <article class="news-card">
-                            <h3 class="news-card__title">
-                                <a href="event.html?title=NeuroAI%20Innovation%20Forum">NeuroAI Innovation Forum</a>
-                            </h3>
-                            <p class="news-card__date">17 June 2025</p>
-                            <p class="news-card__description">Forum interdisciplinare su intelligenza artificiale responsabile e neuroscienze.</p>
+                            <figure class="news-card__media" aria-hidden="true">
+                                <img src="assets/images/news/neuroai-innovation-forum.svg" alt="" loading="lazy">
+                            </figure>
+                            <div class="news-card__content">
+                                <h3 class="news-card__title">
+                                    <a href="event.html?title=NeuroAI%20Innovation%20Forum">NeuroAI Innovation Forum</a>
+                                </h3>
+                                <p class="news-card__date">17 June 2025</p>
+                                <p class="news-card__description">Forum interdisciplinare su intelligenza artificiale responsabile e neuroscienze.</p>
+                            </div>
                         </article>
                     </div>
                 </details>
@@ -113,25 +133,40 @@
                     </summary>
                     <div class="news-year__grid">
                         <article class="news-card">
-                            <h3 class="news-card__title">
-                                <a href="event.html?title=Brain%20Imaging%20Hackathon">Brain Imaging Hackathon</a>
-                            </h3>
-                            <p class="news-card__date">6 December 2024</p>
-                            <p class="news-card__description">Due giorni di lavoro intensivo su dataset aperti di neuroimaging.</p>
+                            <figure class="news-card__media" aria-hidden="true">
+                                <img src="assets/images/news/brain-imaging-hackathon.svg" alt="" loading="lazy">
+                            </figure>
+                            <div class="news-card__content">
+                                <h3 class="news-card__title">
+                                    <a href="event.html?title=Brain%20Imaging%20Hackathon">Brain Imaging Hackathon</a>
+                                </h3>
+                                <p class="news-card__date">6 December 2024</p>
+                                <p class="news-card__description">Due giorni di lavoro intensivo su dataset aperti di neuroimaging.</p>
+                            </div>
                         </article>
                         <article class="news-card">
-                            <h3 class="news-card__title">
-                                <a href="event.html?title=Neuromodulation%20Summer%20School">Neuromodulation Summer School</a>
-                            </h3>
-                            <p class="news-card__date">19 July 2024</p>
-                            <p class="news-card__description">Programma intensivo dedicato a studenti e dottorandi sulle nuove tecniche di neuromodulazione.</p>
+                            <figure class="news-card__media" aria-hidden="true">
+                                <img src="assets/images/news/neuromodulation-summer-school.svg" alt="" loading="lazy">
+                            </figure>
+                            <div class="news-card__content">
+                                <h3 class="news-card__title">
+                                    <a href="event.html?title=Neuromodulation%20Summer%20School">Neuromodulation Summer School</a>
+                                </h3>
+                                <p class="news-card__date">19 July 2024</p>
+                                <p class="news-card__description">Programma intensivo dedicato a studenti e dottorandi sulle nuove tecniche di neuromodulazione.</p>
+                            </div>
                         </article>
                         <article class="news-card">
-                            <h3 class="news-card__title">
-                                <a href="event.html?title=Publication%20-%20Synaptic%20Plasticity%20Review">Publication: Synaptic Plasticity Review</a>
-                            </h3>
-                            <p class="news-card__date">10 May 2024</p>
-                            <p class="news-card__description">Il gruppo AWARENET pubblica una rassegna sulla plasticità sinaptica nelle riviste open access.</p>
+                            <figure class="news-card__media" aria-hidden="true">
+                                <img src="assets/images/news/synaptic-plasticity-review.svg" alt="" loading="lazy">
+                            </figure>
+                            <div class="news-card__content">
+                                <h3 class="news-card__title">
+                                    <a href="event.html?title=Publication%20-%20Synaptic%20Plasticity%20Review">Publication: Synaptic Plasticity Review</a>
+                                </h3>
+                                <p class="news-card__date">10 May 2024</p>
+                                <p class="news-card__description">Il gruppo AWARENET pubblica una rassegna sulla plasticità sinaptica nelle riviste open access.</p>
+                            </div>
                         </article>
                     </div>
                 </details>


### PR DESCRIPTION
## Summary
- add a dedicated media slot and responsive layout so each news archive card can show a thumbnail beside its copy
- provide lightweight SVG illustrations for every event as default thumbnails and enable lazy loading for the images

## Testing
- not run (static content)


------
https://chatgpt.com/codex/tasks/task_e_68e5083f0b44832bb0480c35d9925361