### PR TITLE
Restore color styling for navbar title

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -219,11 +219,11 @@ a:focus {
     font-weight: 700;
     letter-spacing: 0.08em;
     line-height: 1.08;
-    color: #ffffff;
+    color: var(--color-primary);
 }
 
 .navbar__title--accent {
-    color: rgba(255, 255, 255, 0.82);
+    color: var(--color-secondary);
 }
 
 .navbar__toggle {


### PR DESCRIPTION
## Summary
- restore the AWARENET navbar title colors so the name uses the primary and secondary palette

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e50fab1a8c832b8383ddd55eea24be