### PR TITLE
Adjust contact card layout spacing

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -635,8 +635,9 @@ a:focus {
 
 .contact-card {
     display: grid;
-    gap: 0.55rem;
-    padding: clamp(0.95rem, 1.8vw, 1.6rem);
+    gap: clamp(0.8rem, 1.8vw, 1.1rem);
+    padding: clamp(1.2rem, 2.4vw, 2.15rem) clamp(1rem, 2vw, 1.75rem);
+    min-height: clamp(12.5rem, 18vw, 14.75rem);
     background: rgba(255, 255, 255, 0.88);
     border: 1px solid var(--surface-border);
     border-radius: 18px;
@@ -655,6 +656,7 @@ a:focus {
     border: none;
     box-shadow: none;
     overflow: hidden;
+    margin-bottom: clamp(0.35rem, 1vw, 0.6rem);
 }
 
 .contact-card__icon img {


### PR DESCRIPTION
## Summary
- increase the height and padding of contact cards so they appear taller without extending beyond the viewport
- add extra spacing between the contact icons and text for improved readability

## Testing
- not run (static changes)


------
https://chatgpt.com/codex/tasks/task_e_68e51491bcf0832b85552d72fa37a56b