### PR TITLE
Adjust contact form spacing for better viewport fit

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -1142,11 +1142,11 @@ a:focus {
 
 
 .contact-page .section {
-    padding-block: clamp(2.4rem, 7vh, 3.6rem);
+    padding-block: clamp(2rem, 6vh, 3.2rem);
 }
 
 .contact-message-section .contact-panel {
-    max-width: min(720px, 100%);
+    max-width: min(680px, 100%);
     margin-inline: auto;
     width: 100%;
 }
@@ -1172,8 +1172,8 @@ a:focus {
 
 .contact-form {
     display: grid;
-    gap: 0.55rem;
-    padding: 1.1rem 1.6rem 1.3rem;
+    gap: 0.45rem;
+    padding: 0.95rem 1.35rem 1.1rem;
     background: rgba(255, 255, 255, 0.85);
     border-radius: 18px;
     box-shadow: var(--shadow-sm);
@@ -1194,7 +1194,7 @@ a:focus {
 .form-field textarea {
     border: 1px solid var(--surface-border);
     border-radius: 10px;
-    padding: 0.75rem 1rem;
+    padding: 0.65rem 0.9rem;
     font: inherit;
     background: white;
     color: var(--color-text);
@@ -1232,7 +1232,7 @@ a:focus {
     display: inline-flex;
     align-items: center;
     justify-content: center;
-    padding: 0.75rem 1.5rem;
+    padding: 0.65rem 1.35rem;
     border-radius: 999px;
     background: var(--gradient-button);
     color: white;


### PR DESCRIPTION
## Summary
- reduce the contact section padding and panel width so the form fits within a standard viewport
- tighten the contact form, field, and button padding to decrease its vertical footprint

## Testing
- none

------
https://chatgpt.com/codex/tasks/task_e_68e514ade58c832b980ab17e10d397a4