### PR TITLE
Adjust partner section styling

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -400,7 +400,7 @@ a:focus {
 
 .hero-institutions .section__content p {
     color: var(--color-muted);
-    font-size: clamp(0.55rem, calc((min(100vw, 1100px) - 4rem) / 78), 1.1rem);
+    font-size: 1.05rem;
     white-space: nowrap;
 }
 
@@ -412,26 +412,19 @@ a:focus {
 
 .institution-card {
     display: grid;
-    gap: 1rem;
-    padding: 1.65rem;
-    border-radius: 1.35rem;
-    background: rgba(64, 89, 142, 0.12);
-    border: 1px solid rgba(64, 89, 142, 0.16);
-    box-shadow: 0 18px 36px rgba(64, 89, 142, 0.14);
+    gap: 1.1rem;
+    padding: 0;
     text-align: center;
 }
 
 .institution-card__logo {
-    width: min(180px, 100%);
-    height: 120px;
+    width: min(230px, 100%);
+    height: clamp(130px, 14vw, 170px);
     margin: 0 auto;
-    border-radius: 1rem;
-    border: 2px dashed rgba(64, 89, 142, 0.3);
-    background: rgba(255, 255, 255, 0.9);
     display: flex;
     align-items: center;
     justify-content: center;
-    padding: 0.75rem;
+    padding: 0;
     overflow: hidden;
 }
 
@@ -439,13 +432,13 @@ a:focus {
     max-width: 100%;
     max-height: 100%;
     object-fit: contain;
-    filter: drop-shadow(0 6px 12px rgba(64, 89, 142, 0.08));
+    filter: drop-shadow(0 6px 12px rgba(64, 89, 142, 0.12));
 }
 
 .institution-card h3 {
     margin: 0;
-    font-size: 1.08rem;
-    color: var(--color-primary);
+    font-size: 1.12rem;
+    color: #071a3c;
 }
 
 .hero-media {


### PR DESCRIPTION
## Summary
- remove decorative frames from partner institution cards and align the section with the page background
- enlarge partner logos and darken institution subtitles for better emphasis
- match the partner section description text size to the team section lead paragraph

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e515cf3d5c832b845ab74c11e12b5b