### PR TITLE
Add contact form email handoff structure

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -1205,6 +1205,21 @@ a:focus {
     resize: vertical;
 }
 
+.form-status {
+    margin-top: 0.9rem;
+    font-size: 0.95rem;
+    color: var(--color-muted);
+    min-height: 1.5rem;
+}
+
+.form-status--success {
+    color: var(--color-primary);
+}
+
+.form-status--error {
+    color: #b24d57;
+}
+
 .hero-highlight {
     background: var(--card-fill);
     border: 1px solid var(--card-border);

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -44,4 +44,64 @@ document.addEventListener('DOMContentLoaded', () => {
             description.classList.toggle('event-detail__placeholder--wrap', hasMedia);
         }
     }
+
+    const contactForm = document.querySelector('[data-contact-form]');
+    if (contactForm) {
+        const statusMessage = contactForm.querySelector('[data-form-status]');
+        const contactEmail = (contactForm.dataset.contactEmail || '').trim();
+
+        const updateStatus = (message, tone = 'info') => {
+            if (!statusMessage) {
+                return;
+            }
+
+            statusMessage.textContent = message;
+            statusMessage.classList.remove('form-status--success', 'form-status--error');
+
+            if (tone === 'success') {
+                statusMessage.classList.add('form-status--success');
+            } else if (tone === 'error') {
+                statusMessage.classList.add('form-status--error');
+            }
+        };
+
+        contactForm.addEventListener('submit', (event) => {
+            event.preventDefault();
+
+            if (!contactEmail) {
+                updateStatus('The email service is not configured yet. Please try again soon.', 'error');
+                return;
+            }
+
+            const formData = new FormData(contactForm);
+            const getValue = (field) => {
+                const value = formData.get(field);
+                return value ? String(value).trim() : '';
+            };
+
+            const name = getValue('name');
+            const email = getValue('email');
+            const organization = getValue('organization');
+            const message = getValue('message');
+
+            const emailLines = [
+                'You have received a new contact request from the AWARENET website.',
+                '',
+                `Name: ${name || 'Not provided'}`,
+                `Email: ${email || 'Not provided'}`,
+                `Organization: ${organization || 'Not provided'}`,
+                '',
+                'Message:',
+                message || 'No message provided.'
+            ];
+
+            const subject = encodeURIComponent(`New contact request from ${name || 'AWARENET website'}`);
+            const body = encodeURIComponent(emailLines.join('\n'));
+            const mailtoLink = `mailto:${contactEmail}?subject=${subject}&body=${body}`;
+
+            window.location.href = mailtoLink;
+            updateStatus('We have opened your email client to finalize the request. Please press send to complete your message.', 'success');
+            contactForm.reset();
+        });
+    }
 });

--- a/contact.html
+++ b/contact.html
@@ -64,7 +64,7 @@
                 <h2 id="contact-form-title">Send us a message</h2>
             </div>
             <div class="contact-panel">
-                <form class="contact-form" aria-label="Contact form">
+                <form class="contact-form" aria-label="Contact form" data-contact-form data-contact-email="contact@awarenet.org">
                     <div class="form-field">
                         <label for="contact-name">Name</label>
                         <input type="text" id="contact-name" name="name" placeholder="Your name" required>
@@ -82,6 +82,7 @@
                         <textarea id="contact-message" name="message" rows="4" placeholder="How can we help you?" required></textarea>
                     </div>
                     <button type="submit" class="button">Send request</button>
+                    <p class="form-status" data-form-status role="status" aria-live="polite"></p>
                 </form>
             </div>
         </section>


### PR DESCRIPTION
## Summary
- add a data-configurable email target and status area to the contact form for future forwarding
- implement client-side handling that assembles a mailto request until the mailbox is provisioned
- style the form status helper so visitors receive visual feedback when sending a request

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68e51aea1c18832ba11a3a8a65e7655a