### PR TITLE
Add organization suggestions to contact form

### DIFF
--- a/contact.html
+++ b/contact.html
@@ -75,7 +75,35 @@
                     </div>
                     <div class="form-field">
                         <label for="contact-organization">Organization</label>
-                        <input type="text" id="contact-organization" name="organization" placeholder="Company or institution">
+                        <input type="text" id="contact-organization" name="organization" list="organization-options" placeholder="Company or institution">
+                        <datalist id="organization-options">
+                            <option value="Politecnico di Milano">
+                            <option value="Università di Bologna">
+                            <option value="Sapienza Università di Roma">
+                            <option value="Università di Padova">
+                            <option value="Politecnico di Torino">
+                            <option value="Università di Pisa">
+                            <option value="CNR - Consiglio Nazionale delle Ricerche">
+                            <option value="Istituto Superiore di Sanità">
+                            <option value="University of Oxford">
+                            <option value="University of Cambridge">
+                            <option value="ETH Zürich">
+                            <option value="EPFL">
+                            <option value="Technical University of Munich">
+                            <option value="KU Leuven">
+                            <option value="University of Copenhagen">
+                            <option value="European Commission - DG Research & Innovation">
+                            <option value="Massachusetts Institute of Technology (MIT)">
+                            <option value="Stanford University">
+                            <option value="Harvard University">
+                            <option value="University of California, Berkeley">
+                            <option value="Tsinghua University">
+                            <option value="National University of Singapore">
+                            <option value="The University of Tokyo">
+                            <option value="University of Melbourne">
+                            <option value="UNESCO">
+                            <option value="World Bank">
+                        </datalist>
                     </div>
                     <div class="form-field">
                         <label for="contact-message">Message</label>


### PR DESCRIPTION
## Summary
- enhance the contact form organization field with a datalist of Italian, European, and global universities and institutions
- allow visitors to either select from the curated suggestions or enter their own organization name

## Testing
- No automated tests were run (static HTML change)


------
https://chatgpt.com/codex/tasks/task_e_68e51b442378832bb7f1dc624c8d162d