### PR TITLE
Align contact page text to the left

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -614,8 +614,9 @@ a:focus {
 }
 
 .contact-intro__heading {
-    justify-items: center;
-    text-align: center;
+    justify-items: start;
+    align-items: start;
+    text-align: left;
     max-width: 100%;
 }
 
@@ -635,6 +636,8 @@ a:focus {
     border: 1px solid var(--card-border);
     border-radius: 18px;
     box-shadow: var(--shadow-sm);
+    justify-items: start;
+    text-align: left;
 }
 
 .contact-card__icon {


### PR DESCRIPTION
## Summary
- left-align the contact page hero heading and description
- left-align the text content inside individual contact cards for consistent presentation

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e51e43a824832bbf1cc3e2f51157af