### PR TITLE
Adjust contact form message box sizing

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -1144,7 +1144,7 @@ a:focus {
 }
 
 .contact-message-section .contact-panel {
-    max-width: min(620px, 100%);
+    max-width: min(680px, 100%);
     margin-inline: auto;
     width: 100%;
 }
@@ -1206,6 +1206,8 @@ a:focus {
 
 .form-field textarea {
     resize: vertical;
+    height: 5.25rem;
+    min-height: 5.25rem;
 }
 
 .form-status {

--- a/contact.html
+++ b/contact.html
@@ -108,7 +108,7 @@
                     </div>
                     <div class="form-field">
                         <label for="contact-message">Message</label>
-                        <textarea id="contact-message" name="message" rows="4" placeholder="How can we help you?" required></textarea>
+                        <textarea id="contact-message" name="message" rows="3" placeholder="How can we help you?" required></textarea>
                     </div>
                     <button type="submit" class="button">Send request</button>
                     <p class="form-status" data-form-status role="status" aria-live="polite"></p>


### PR DESCRIPTION
## Summary
- decrease the default height of the contact form message field while keeping it resizable
- widen the contact panel so the form spreads slightly more horizontally

## Testing
- no automated tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68e51ff36cb4832ba2a094eee5cfc203