### PR TITLE
Adjust header spacing and color for news and contact pages

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -66,7 +66,7 @@ body.theme-horizon {
     --color-accent: #d7cade;
     --shadow-sm: 0 4px 14px rgba(58, 104, 153, 0.14);
     --gradient-background: linear-gradient(180deg, #f7f8ff 0%, #f2f1fb 52%, #f5eee7 100%);
-    --gradient-header: linear-gradient(120deg, rgba(246, 249, 255, 0.96) 0%, rgba(248, 241, 246, 0.9) 100%);
+    --gradient-header: linear-gradient(120deg, rgba(248, 247, 255, 0.96) 0%, rgba(250, 243, 249, 0.92) 100%);
     --gradient-crest: linear-gradient(135deg, #3a6a9b 0%, #a07aa7 100%);
     --gradient-button: linear-gradient(135deg, #a07aa7, #7f90b8);
     --gradient-button-secondary: linear-gradient(135deg, #3a6a9b, #5681b0);
@@ -1140,7 +1140,7 @@ a:focus {
 
 
 .contact-page .section {
-    padding-block: clamp(2rem, 6vh, 3.2rem);
+    padding-block: 5rem;
 }
 
 .contact-message-section .contact-panel {


### PR DESCRIPTION
## Summary
- align the contact page section padding with the global spacing so the header height matches the news page
- update the news theme header gradient to reuse the contact header color for visual consistency

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e5213d2e98832b9767ac35970ec170