### PR TITLE
Align all pages with news background theme

### DIFF
--- a/contact.html
+++ b/contact.html
@@ -9,7 +9,7 @@
     <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;500;600;700&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="assets/css/styles.css">
 </head>
-<body class="theme-dawn contact-page">
+<body class="theme-horizon contact-page">
     <header class="site-header">
         <nav class="navbar">
             <a class="navbar__brand" href="index.html" aria-label="AWARENET">

--- a/index.html
+++ b/index.html
@@ -10,7 +10,7 @@
     <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;500;600;700&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="assets/css/styles.css">
 </head>
-<body class="theme-dawn">
+<body class="theme-horizon">
     <header class="site-header">
         <nav class="navbar">
             <a class="navbar__brand" href="index.html" aria-label="AWARENET">

--- a/team.html
+++ b/team.html
@@ -9,7 +9,7 @@
     <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;500;600;700&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="assets/css/styles.css">
 </head>
-<body class="theme-dusk">
+<body class="theme-horizon">
     <header class="site-header">
         <nav class="navbar">
             <a class="navbar__brand" href="index.html" aria-label="AWARENET">


### PR DESCRIPTION
## Summary
- set the body theme on the home, team, and contact pages to `theme-horizon`
- ensure every page now shares the same gradient background used on the news page

## Testing
- Manually verified the updated background across pages

------
https://chatgpt.com/codex/tasks/task_e_68e524fac880832baedc4ea121c3d147