### PR TITLE
Align partner institutions hero layout with team section

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -401,6 +401,10 @@ a:focus {
     display: grid;
     gap: clamp(2rem, 4vw, 3.5rem);
     align-content: start;
+    width: min(100%, var(--layout-fluid-width));
+    margin: 0 auto;
+    padding-inline: var(--layout-section-padding);
+    box-sizing: border-box;
 }
 
 .hero-institutions .section__content {


### PR DESCRIPTION
## Summary
- match the partner institutions hero layout padding to the shared layout spacing so the heading lines up with the team section

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68e5263fe0d8832b8ea4c2a6a4c408b9