### PR TITLE
Adjust partner logo sizing

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -452,11 +452,19 @@ a:focus {
     overflow: hidden;
 }
 
+.institution-card:first-child .institution-card__logo {
+    overflow: visible;
+}
+
 .institution-card__logo img {
     max-width: 100%;
     max-height: 100%;
     object-fit: contain;
     filter: drop-shadow(0 6px 12px rgba(64, 89, 142, 0.12));
+}
+
+.institution-card:first-child .institution-card__logo img {
+    transform: scale(1.12);
 }
 
 .institution-card h3 {


### PR DESCRIPTION
## Summary
- enlarge the first partner institution logo while keeping the others consistent
- allow the scaled logo to render cleanly by letting its container overflow

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e52a8d0e74832bb7a62f87c0193a7c