### PR TITLE
Add media and descriptions to news highlights

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -775,9 +775,17 @@ a:focus {
 }
 
 .highlight-card__body {
-    display: grid;
-    gap: 0.6rem;
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
     padding: 0 1.3rem 1.55rem;
+}
+
+.highlight-card__header {
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-start;
+    gap: 1rem;
 }
 
 .highlight-card__title {
@@ -785,6 +793,8 @@ a:focus {
     font-size: 1.2rem;
     line-height: 1.35;
     color: var(--color-primary);
+    flex: 1;
+    min-width: 0;
 }
 
 .highlight-card__title a {
@@ -800,6 +810,7 @@ a:focus {
     margin: 0;
     color: var(--color-muted);
     font-weight: 500;
+    white-space: nowrap;
 }
 
 .highlight-card__description {

--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -761,8 +761,17 @@ a:focus {
 }
 
 .highlight-card__media {
+    margin: 0;
     background: linear-gradient(135deg, rgba(58, 104, 153, 0.35), rgba(160, 122, 167, 0.5));
     aspect-ratio: 5 / 4;
+    overflow: hidden;
+}
+
+.highlight-card__media img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    display: block;
 }
 
 .highlight-card__body {
@@ -791,6 +800,12 @@ a:focus {
     margin: 0;
     color: var(--color-muted);
     font-weight: 500;
+}
+
+.highlight-card__description {
+    margin: 0;
+    color: var(--color-text);
+    line-height: 1.5;
 }
 
 .news-archive__accordion {

--- a/news.html
+++ b/news.html
@@ -37,7 +37,7 @@
             </div>
             <div class="highlights-grid" role="list">
                 <article class="highlight-card" role="listitem">
-                    <div class="highlight-card__media" aria-hidden="true"></div>
+                    <figure class="highlight-card__media" aria-hidden="true"></figure>
                     <div class="highlight-card__body">
                         <h2 class="highlight-card__title">
                             <a href="event.html?title=Sophie%20Scott%20-%20The%20neurobiology%20of%20auditory%20processing">The neurobiology of auditory processing</a>
@@ -46,7 +46,7 @@
                     </div>
                 </article>
                 <article class="highlight-card" role="listitem">
-                    <div class="highlight-card__media" aria-hidden="true"></div>
+                    <figure class="highlight-card__media" aria-hidden="true"></figure>
                     <div class="highlight-card__body">
                         <h2 class="highlight-card__title">
                             <a href="event.html?title=Cristina%20Alberini%20-%20From%20bench%20to%20bedside">From bench to bedside</a>
@@ -55,12 +55,15 @@
                     </div>
                 </article>
                 <article class="highlight-card" role="listitem">
-                    <div class="highlight-card__media" aria-hidden="true"></div>
+                    <figure class="highlight-card__media" aria-hidden="true">
+                        <img src="assets/images/news/parma.jpeg" alt="" loading="lazy">
+                    </figure>
                     <div class="highlight-card__body">
                         <h2 class="highlight-card__title">
-                            <a href="event.html?title=Padova%20Neuroscience%20Center%20Open%20Day">Padova Neuroscience Center open day</a>
+                            <a href="event.html?title=Padova%20Neuroscience%20Center%20Open%20Day">Retreat 2025</a>
                         </h2>
-                        <p class="highlight-card__date">12 November 2025</p>
+                        <p class="highlight-card__date">16 October 2025</p>
+                        <p class="highlight-card__description">Annual Retreat of the CNR Institute of Neuroscience in Parma</p>
                     </div>
                 </article>
             </div>

--- a/news.html
+++ b/news.html
@@ -39,31 +39,39 @@
                 <article class="highlight-card" role="listitem">
                     <figure class="highlight-card__media" aria-hidden="true"></figure>
                     <div class="highlight-card__body">
-                        <h2 class="highlight-card__title">
-                            <a href="event.html?title=Sophie%20Scott%20-%20The%20neurobiology%20of%20auditory%20processing">The neurobiology of auditory processing</a>
-                        </h2>
-                        <p class="highlight-card__date">9 October 2025</p>
+                        <div class="highlight-card__header">
+                            <h2 class="highlight-card__title">
+                                <a href="event.html?title=Sophie%20Scott%20-%20The%20neurobiology%20of%20auditory%20processing">The neurobiology of auditory processing</a>
+                            </h2>
+                            <p class="highlight-card__date">9 October 2025</p>
+                        </div>
+                        <p class="highlight-card__description">A keynote lecture exploring the latest discoveries in how the brain decodes and responds to complex sounds.</p>
                     </div>
                 </article>
                 <article class="highlight-card" role="listitem">
                     <figure class="highlight-card__media" aria-hidden="true"></figure>
                     <div class="highlight-card__body">
-                        <h2 class="highlight-card__title">
-                            <a href="event.html?title=Cristina%20Alberini%20-%20From%20bench%20to%20bedside">From bench to bedside</a>
-                        </h2>
-                        <p class="highlight-card__date">21 October 2025</p>
+                        <div class="highlight-card__header">
+                            <h2 class="highlight-card__title">
+                                <a href="event.html?title=Cristina%20Alberini%20-%20From%20bench%20to%20bedside">From bench to bedside</a>
+                            </h2>
+                            <p class="highlight-card__date">21 October 2025</p>
+                        </div>
+                        <p class="highlight-card__description">Cristina Alberini illustrates how translational neuroscience transforms lab findings into patient-centred therapies.</p>
                     </div>
                 </article>
                 <article class="highlight-card" role="listitem">
                     <figure class="highlight-card__media" aria-hidden="true">
-                        <img src="assets/images/news/parma.jpeg" alt="" loading="lazy">
+                        <img src="assets/images/news/parma.jpeg" alt="Researchers networking during the Retreat 2025 in Parma" loading="lazy">
                     </figure>
                     <div class="highlight-card__body">
-                        <h2 class="highlight-card__title">
-                            <a href="event.html?title=Padova%20Neuroscience%20Center%20Open%20Day">Retreat 2025</a>
-                        </h2>
-                        <p class="highlight-card__date">16 October 2025</p>
-                        <p class="highlight-card__description">Annual Retreat of the CNR Institute of Neuroscience in Parma</p>
+                        <div class="highlight-card__header">
+                            <h2 class="highlight-card__title">
+                                <a href="event.html?title=Padova%20Neuroscience%20Center%20Open%20Day">Retreat 2025</a>
+                            </h2>
+                            <p class="highlight-card__date">16 October 2025</p>
+                        </div>
+                        <p class="highlight-card__description">Annual Retreat of the CNR Institute of Neuroscience in Parma.</p>
                     </div>
                 </article>
             </div>


### PR DESCRIPTION
## Summary
- render highlight cards with figure wrappers to support optional images
- display the Retreat 2025 highlight with event imagery and descriptive copy
- style highlight media and descriptions for consistent presentation

## Testing
- no automated tests were run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68e52b17493c832bb0ac29e98c533a78