### PR TITLE
Maintain highlight card width when fewer news items

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -753,10 +753,20 @@ a:focus {
 
 .highlights-grid {
     display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
     gap: clamp(1.25rem, 2.5vw, 2rem);
     align-items: stretch;
-    justify-content: center;
+}
+
+@media (min-width: 48rem) {
+    .highlights-grid {
+        grid-template-columns: repeat(2, minmax(260px, 1fr));
+    }
+}
+
+@media (min-width: 64rem) {
+    .highlights-grid {
+        grid-template-columns: repeat(3, minmax(260px, 1fr));
+    }
 }
 
 .highlight-card {


### PR DESCRIPTION
## Summary
- update the highlights grid layout to enforce consistent column widths on larger screens
- ensure the section remains single-column on small viewports while reserving empty space for missing cards

## Testing
- Manual visual verification

------
https://chatgpt.com/codex/tasks/task_e_68e52c1ca38c832bb34f43a1797cae9f