### PR TITLE
Align contact cards background with index styling

### DIFF
--- a/contact.html
+++ b/contact.html
@@ -36,21 +36,21 @@
                 <p class="contact-intro__description">For inquiries regarding collaborations, partnerships, or any general matters, please feel free to reach out to us or arrange a meeting at our main office. We look forward to your communication.</p>
             </div>
             <div class="contact-info__grid" role="list">
-                <article class="contact-card" role="listitem">
+                <article class="contact-card card" role="listitem">
                     <span class="contact-card__icon" aria-hidden="true">
                         <img src="assets/images/contact/icons/mail_icon.png" alt="">
                     </span>
                     <h2 class="contact-card__title">Email</h2>
                     <p>Write to <a href="mailto:info@awarenet.org">info@awarenet.org</a></p>
                 </article>
-                <article class="contact-card" role="listitem">
+                <article class="contact-card card" role="listitem">
                     <span class="contact-card__icon" aria-hidden="true">
                         <img src="assets/images/contact/icons/office_phone_icon.png" alt="">
                     </span>
                     <h2 class="contact-card__title">Phone</h2>
                     <p>Call us at <a href="tel:+390497654321">+39 049 7654321</a>.</p>
                 </article>
-                <article class="contact-card" role="listitem">
+                <article class="contact-card card" role="listitem">
                     <span class="contact-card__icon" aria-hidden="true">
                         <img src="assets/images/contact/icons/placeholder.png" alt="">
                     </span>


### PR DESCRIPTION
## Summary
- add the shared card styling class to the contact page tiles so they inherit the same background color used on the home page

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e5783f9f7c832b84bc12883c788a88