### PR TITLE
Reformat news archive cards into stacked layout

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -901,21 +901,19 @@ a:focus {
 }
 
 .news-card {
-    display: flex;
-    gap: 1rem;
+    display: grid;
+    gap: 1.1rem;
     padding: 1.2rem;
     background: rgba(245, 246, 255, 0.9);
     border: 1px solid var(--card-border);
     border-radius: 18px;
     box-shadow: var(--shadow-sm);
-    align-items: flex-start;
 }
 
 .news-card__media {
-    flex: 0 0 96px;
-    width: 96px;
-    aspect-ratio: 1 / 1;
-    border-radius: 16px;
+    width: 100%;
+    aspect-ratio: 4 / 3;
+    border-radius: 14px;
     overflow: hidden;
     background: var(--card-fill);
     display: flex;
@@ -935,7 +933,6 @@ a:focus {
 .news-card__content {
     display: grid;
     gap: 0.55rem;
-    flex: 1 1 auto;
 }
 
 .news-card__title {
@@ -970,16 +967,12 @@ a:focus {
 }
 
 @media (max-width: 720px) {
-    .news-card {
-        flex-direction: column;
-        align-items: stretch;
+    .news-year__grid {
+        grid-template-columns: 1fr;
     }
 
-    .news-card__media {
-        width: 100%;
-        max-width: 320px;
-        aspect-ratio: 4 / 3;
-        margin: 0 auto;
+    .news-card {
+        padding: 1rem;
     }
 
     .news-card__content {


### PR DESCRIPTION
## Summary
- restyle the news archive cards to stack media above the content for a quadrant-style layout
- ensure the archive grid collapses to a single column on small viewports while preserving spacing

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e579388a7c832b8f2003581d0fac74