### PR TITLE
Reduce team photo space

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -1094,7 +1094,7 @@ a:focus {
 }
 
 .team-card__photo {
-    aspect-ratio: 4 / 3;
+    aspect-ratio: 16 / 9;
     display: grid;
     place-items: center;
     background: linear-gradient(135deg, rgba(64, 89, 142, 0.16) 0%, rgba(176, 138, 165, 0.2) 100%);


### PR DESCRIPTION
## Summary
- decrease the team card photo aspect ratio to reduce the placeholder height

## Testing
- no tests were run

------
https://chatgpt.com/codex/tasks/task_e_68e57dd4da48832b8565129990cd3080