### PR TITLE
Stack news card text vertically

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -774,22 +774,22 @@ a:focus {
 }
 
 .highlight-card {
-    --highlight-title-lines: 2.6;
+    --highlight-title-lines: 2.4;
     display: grid;
     grid-template-rows: auto 1fr;
-    gap: 0.65rem;
+    gap: 0.5rem;
     background: rgba(255, 255, 255, 0.92);
     border: 1px solid var(--card-border);
     border-radius: 18px;
     overflow: hidden;
     box-shadow: var(--shadow-sm);
-    min-height: clamp(220px, 28vw, 260px);
+    min-height: clamp(200px, 24vw, 240px);
 }
 
 .highlight-card__media {
     margin: 0;
     background: linear-gradient(135deg, rgba(58, 104, 153, 0.35), rgba(160, 122, 167, 0.5));
-    aspect-ratio: 5 / 4;
+    aspect-ratio: 16 / 9;
     overflow: hidden;
 }
 
@@ -804,23 +804,21 @@ a:focus {
     display: flex;
     flex-direction: column;
     gap: 0.75rem;
-    padding: 0 1.3rem 1.55rem;
+    padding: 0 1.1rem 1.35rem;
 }
 
 .highlight-card__header {
     display: flex;
-    justify-content: space-between;
+    flex-direction: column;
     align-items: flex-start;
-    gap: 1rem;
+    gap: 0.35rem;
 }
 
 .highlight-card__title {
     margin: 0;
-    font-size: 1.1rem;
+    font-size: 1.15rem;
     line-height: 1.35;
     color: var(--color-primary);
-    flex: 1;
-    min-width: 0;
 }
 
 .highlight-card__title a {
@@ -836,13 +834,14 @@ a:focus {
     margin: 0;
     color: var(--color-muted);
     font-weight: 500;
-    white-space: nowrap;
+    font-size: 1rem;
 }
 
 .highlight-card__description {
     margin: 0;
     color: var(--color-text);
     line-height: 1.5;
+    font-size: 0.95rem;
 }
 
 .news-archive__accordion {
@@ -902,8 +901,8 @@ a:focus {
 
 .news-card {
     display: flex;
-    gap: 1rem;
-    padding: 1.2rem;
+    gap: 0.85rem;
+    padding: 1rem;
     background: rgba(245, 246, 255, 0.9);
     border: 1px solid var(--card-border);
     border-radius: 18px;
@@ -912,10 +911,10 @@ a:focus {
 }
 
 .news-card__media {
-    flex: 0 0 96px;
-    width: 96px;
+    flex: 0 0 82px;
+    width: 82px;
     aspect-ratio: 1 / 1;
-    border-radius: 16px;
+    border-radius: 14px;
     overflow: hidden;
     background: var(--card-fill);
     display: flex;
@@ -967,6 +966,7 @@ a:focus {
 .news-card__description {
     margin: 0;
     color: var(--color-text);
+    font-size: 0.95rem;
 }
 
 @media (max-width: 720px) {


### PR DESCRIPTION
## Summary
- stack highlight card titles, dates, and descriptions vertically with descending font sizes
- ensure archive news cards follow the same typographic hierarchy without enlarging cards

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e5787358f0832ba80fe51e62578435