### PR TITLE
Simplify team cards

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -1094,7 +1094,7 @@ a:focus {
 }
 
 .team-card__photo {
-    aspect-ratio: 4 / 3;
+    aspect-ratio: 16 / 9;
     display: grid;
     place-items: center;
     background: linear-gradient(135deg, rgba(64, 89, 142, 0.16) 0%, rgba(176, 138, 165, 0.2) 100%);

--- a/team.html
+++ b/team.html
@@ -72,12 +72,6 @@
                     <div class="team-card__body">
                         <h3>Serena Bianchi</h3>
                         <p class="team-card__role">Principal Investigator</p>
-                        <p class="team-card__bio">Coordinates cross-institutional studies on awareness-driven AI and oversees strategic partnerships.</p>
-                        <ul class="team-card__links" aria-label="Serena Bianchi social links">
-                            <li><a href="#" class="team-card__link" aria-label="LinkedIn profile"><img src="assets/images/team/icons/linkedin.jpg" alt="" class="team-card__link-icon"></a></li>
-                            <li><a href="#" class="team-card__link" aria-label="Google Scholar profile"><img src="assets/images/team/icons/googlescholar.jpg" alt="" class="team-card__link-icon"></a></li>
-                            <li><a href="#" class="team-card__link" aria-label="Personal website"><img src="assets/images/team/icons/website.jpg" alt="" class="team-card__link-icon"></a></li>
-                        </ul>
                     </div>
                 </article>
                 <article class="team-card">
@@ -87,12 +81,6 @@
                     <div class="team-card__body">
                         <h3>Luca Marino</h3>
                         <p class="team-card__role">Research Scientist</p>
-                        <p class="team-card__bio">Designs experiments that blend cognitive science with machine learning to improve interpretability.</p>
-                        <ul class="team-card__links" aria-label="Luca Marino social links">
-                            <li><a href="#" class="team-card__link" aria-label="Email Luca Marino"><img src="assets/images/team/icons/mail.jpg" alt="" class="team-card__link-icon"></a></li>
-                            <li><a href="#" class="team-card__link" aria-label="GitHub profile"><img src="assets/images/team/icons/github.svg" alt="" class="team-card__link-icon"></a></li>
-                            <li><a href="#" class="team-card__link" aria-label="Personal website"><img src="assets/images/team/icons/website.jpg" alt="" class="team-card__link-icon"></a></li>
-                        </ul>
                     </div>
                 </article>
                 <article class="team-card">
@@ -102,11 +90,6 @@
                     <div class="team-card__body">
                         <h3>Elisa Conti</h3>
                         <p class="team-card__role">PhD Student</p>
-                        <p class="team-card__bio">Investigates neural markers that inform adaptive feedback loops for human-in-the-loop systems.</p>
-                        <ul class="team-card__links" aria-label="Elisa Conti social links">
-                            <li><a href="#" class="team-card__link" aria-label="LinkedIn profile"><img src="assets/images/team/icons/linkedin.jpg" alt="" class="team-card__link-icon"></a></li>
-                            <li><a href="#" class="team-card__link" aria-label="Google Scholar profile"><img src="assets/images/team/icons/googlescholar.jpg" alt="" class="team-card__link-icon"></a></li>
-                        </ul>
                     </div>
                 </article>
                 <article class="team-card">
@@ -116,12 +99,6 @@
                     <div class="team-card__body">
                         <h3>Marco Greco</h3>
                         <p class="team-card__role">Machine Learning Engineer</p>
-                        <p class="team-card__bio">Builds scalable pipelines that translate lab prototypes into reliable and secure applications.</p>
-                        <ul class="team-card__links" aria-label="Marco Greco social links">
-                            <li><a href="#" class="team-card__link" aria-label="LinkedIn profile"><img src="assets/images/team/icons/linkedin.jpg" alt="" class="team-card__link-icon"></a></li>
-                            <li><a href="#" class="team-card__link" aria-label="GitHub profile"><img src="assets/images/team/icons/github.svg" alt="" class="team-card__link-icon"></a></li>
-                            <li><a href="#" class="team-card__link" aria-label="Personal website"><img src="assets/images/team/icons/website.jpg" alt="" class="team-card__link-icon"></a></li>
-                        </ul>
                     </div>
                 </article>
                 <article class="team-card">
@@ -131,12 +108,6 @@
                     <div class="team-card__body">
                         <h3>Giulia Ferraro</h3>
                         <p class="team-card__role">Postdoctoral Fellow</p>
-                        <p class="team-card__bio">Explores ethical AI frameworks that align regulatory requirements with technical implementation.</p>
-                        <ul class="team-card__links" aria-label="Giulia Ferraro social links">
-                            <li><a href="#" class="team-card__link" aria-label="Email Giulia Ferraro"><img src="assets/images/team/icons/mail.jpg" alt="" class="team-card__link-icon"></a></li>
-                            <li><a href="#" class="team-card__link" aria-label="Google Scholar profile"><img src="assets/images/team/icons/googlescholar.jpg" alt="" class="team-card__link-icon"></a></li>
-                            <li><a href="#" class="team-card__link" aria-label="LinkedIn profile"><img src="assets/images/team/icons/linkedin.jpg" alt="" class="team-card__link-icon"></a></li>
-                        </ul>
                     </div>
                 </article>
                 <article class="team-card">
@@ -146,10 +117,6 @@
                     <div class="team-card__body">
                         <h3>Andrea Rinaldi</h3>
                         <p class="team-card__role">Cognitive Scientist</p>
-                        <p class="team-card__bio">Leads behavioural studies to ensure emerging interfaces remain accessible and inclusive for all users.</p>
-                        <ul class="team-card__links" aria-label="Andrea Rinaldi social links">
-                            <li><a href="#" class="team-card__link" aria-label="Personal website"><img src="assets/images/team/icons/website.jpg" alt="" class="team-card__link-icon"></a></li>
-                        </ul>
                     </div>
                 </article>
             </div>


### PR DESCRIPTION
## Summary
- decrease the team card photo aspect ratio to reduce the placeholder height
- remove bios and social link text from team cards, leaving only name and role

## Testing
- no tests were run

------
https://chatgpt.com/codex/tasks/task_e_68e57dd4da48832b8565129990cd3080