### PR TITLE
Adjust news card layout

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -896,9 +896,10 @@ a:focus {
     transform: rotate(180deg);
 }
 
+
 .news-year__grid {
     display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+    grid-template-columns: repeat(3, minmax(0, 1fr));
     gap: 1.5rem;
     padding: 0 1.75rem 1.75rem;
     justify-items: center;
@@ -906,7 +907,10 @@ a:focus {
 
 .news-card {
     display: flex;
-    gap: 0.85rem;
+    flex-direction: column;
+    gap: 1rem;
+    width: 100%;
+    max-width: 320px;
     padding: 1rem;
     background: rgba(245, 246, 255, 0.9);
     border: 1px solid var(--card-border);
@@ -915,9 +919,8 @@ a:focus {
 }
 
 .news-card__media {
-    flex: 0 0 82px;
-    width: 82px;
-    aspect-ratio: 1 / 1;
+    width: 100%;
+    aspect-ratio: 4 / 3;
     border-radius: 14px;
     overflow: hidden;
     background: var(--card-fill);
@@ -937,7 +940,7 @@ a:focus {
 
 .news-card__content {
     display: grid;
-    gap: 0.55rem;
+    gap: 0.65rem;
 }
 
 .news-card__title {
@@ -956,7 +959,7 @@ a:focus {
 }
 
 .news-card__date {
-    margin: 0;
+    margin: 0.35rem 0 0;
     color: var(--color-muted);
     font-weight: 600;
     font-size: 1.1rem;
@@ -983,6 +986,12 @@ a:focus {
 
     .news-card__content {
         gap: 0.65rem;
+    }
+}
+
+@media (max-width: 1100px) and (min-width: 721px) {
+    .news-year__grid {
+        grid-template-columns: repeat(2, minmax(0, 1fr));
     }
 }
 


### PR DESCRIPTION
## Summary
- stack news-card media above the text content with refreshed spacing for dates and descriptions
- enforce a three-column desktop grid while keeping cards compact via max-width and responsive fallbacks

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e61a4ff5c0832ba3e13820f05f5cf3