### PR TITLE
Adjust highlight card spacing

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -807,7 +807,7 @@ a:focus {
 .highlight-card__body {
     display: flex;
     flex-direction: column;
-    gap: 0.65rem;
+    gap: 0.85rem;
     padding: 0 1.1rem 1.35rem;
 }
 
@@ -815,7 +815,7 @@ a:focus {
     display: flex;
     flex-direction: column;
     align-items: flex-start;
-    gap: 0.35rem;
+    gap: 0.55rem;
 }
 
 .highlight-card__title {


### PR DESCRIPTION
## Summary
- increase the vertical gap between news highlight card sections for improved readability

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e620482284832b97a411f8618afc52