### PR TITLE
Increase spacing between highlight card media and title

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -781,7 +781,7 @@ a:focus {
     --highlight-title-lines: 2.4;
     display: grid;
     grid-template-rows: auto 1fr;
-    gap: 0.5rem;
+    gap: 0.85rem;
     background: rgba(255, 255, 255, 0.92);
     border: 1px solid var(--card-border);
     border-radius: 18px;


### PR DESCRIPTION
## Summary
- slightly increase the gap between highlight card media and body content to give the title more breathing room

## Testing
- no automated tests were run

------
https://chatgpt.com/codex/tasks/task_e_68e62c292738832b8a4ac326f31699d1