### PR TITLE
Adjust news card layout spacing

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -900,17 +900,17 @@ a:focus {
 .news-year__grid {
     display: grid;
     grid-template-columns: repeat(3, minmax(0, 1fr));
-    gap: 1.5rem;
-    padding: 0 1.75rem 1.75rem;
-    justify-items: center;
+    gap: 1.25rem;
+    padding: 0 1.25rem 1.5rem;
+    justify-items: stretch;
 }
 
 .news-card {
     display: flex;
     flex-direction: column;
-    gap: 1rem;
+    gap: 0.85rem;
     width: 100%;
-    max-width: 320px;
+    max-width: none;
     padding: 1rem;
     background: rgba(245, 246, 255, 0.9);
     border: 1px solid var(--card-border);


### PR DESCRIPTION
## Summary
- widen news archive cards by allowing them to stretch within the grid
- reduce the grid gap to minimise white space between cards
- tighten internal spacing so the cards appear slightly shorter

## Testing
- No automated tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68e62df6f9a0832b917d12c263ea5a4f