### PR TITLE
Tighten news archive card layout

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -903,25 +903,27 @@ a:focus {
     gap: 1.25rem;
     padding: 0 1.25rem 1.5rem;
     justify-items: stretch;
+    max-width: 1040px;
+    margin: 0 auto;
 }
 
 .news-card {
     display: flex;
     flex-direction: column;
-    gap: 0.85rem;
+    gap: 0.75rem;
     width: 100%;
     max-width: none;
-    padding: 1rem;
+    padding: 0.85rem;
     background: rgba(245, 246, 255, 0.9);
     border: 1px solid var(--card-border);
-    border-radius: 18px;
+    border-radius: 16px;
     box-shadow: var(--shadow-sm);
 }
 
 .news-card__media {
     width: 100%;
-    aspect-ratio: 4 / 3;
-    border-radius: 14px;
+    aspect-ratio: 3 / 2;
+    border-radius: 12px;
     overflow: hidden;
     background: var(--card-fill);
     display: flex;
@@ -940,12 +942,12 @@ a:focus {
 
 .news-card__content {
     display: grid;
-    gap: 0.65rem;
+    gap: 0.6rem;
 }
 
 .news-card__title {
     margin: 0;
-    font-size: 1.3rem;
+    font-size: 1.15rem;
     color: var(--color-heading);
 }
 
@@ -959,10 +961,10 @@ a:focus {
 }
 
 .news-card__date {
-    margin: 0.35rem 0 0;
+    margin: 0.3rem 0 0;
     color: var(--color-muted);
     font-weight: 600;
-    font-size: 1.1rem;
+    font-size: 1rem;
 }
 
 .news-card__date--upcoming {
@@ -972,26 +974,28 @@ a:focus {
 .news-card__description {
     margin: 0;
     color: var(--color-text);
-    font-size: 0.95rem;
+    font-size: 0.9rem;
 }
 
 @media (max-width: 720px) {
     .news-year__grid {
         grid-template-columns: 1fr;
+        max-width: none;
     }
 
     .news-card {
-        padding: 1rem;
+        padding: 0.85rem;
     }
 
     .news-card__content {
-        gap: 0.65rem;
+        gap: 0.6rem;
     }
 }
 
 @media (max-width: 1100px) and (min-width: 721px) {
     .news-year__grid {
         grid-template-columns: repeat(2, minmax(0, 1fr));
+        max-width: none;
     }
 }
 


### PR DESCRIPTION
## Summary
- shrink the news archive cards with reduced padding, typography, and media ratios
- constrain the archive grid width so three cards render per row without overwhelming the page
- preserve spacing on smaller breakpoints while keeping the compact styling

## Testing
- no automated tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68e62faaa4f8832b9700c38d248d2ec4