### PR TITLE
Remove purple background from objective icons

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -585,9 +585,9 @@ a:focus {
     display: grid;
     place-items: center;
     border-radius: 24px;
-    background: rgba(218, 205, 233, 0.28);
-    border: 1px solid rgba(160, 122, 167, 0.32);
-    box-shadow: inset 0 10px 18px rgba(255, 255, 255, 0.45);
+    background: transparent;
+    border: none;
+    box-shadow: none;
 }
 
 .objective-card__icon img {


### PR DESCRIPTION
## Summary
- remove the decorative background from the objective card icons to eliminate the purple halo

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e632ec5fc8832b8bc2e8f2316fcf6e