### PR TITLE
Fix goals heading width and card shape

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -549,10 +549,19 @@ a:focus {
     font-size: 1.05rem;
 }
 
+
+.section--goals .section__heading {
+    max-width: 100%;
+}
+
+.section--goals .section__heading p {
+    max-width: none;
+}
+
 .objectives-grid {
     display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
-    gap: clamp(1.5rem, 3vw, 2.75rem);
+    grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+    gap: clamp(1.75rem, 3.5vw, 3rem);
 }
 
 .objective-card {
@@ -562,58 +571,50 @@ a:focus {
     gap: clamp(1.25rem, 2.5vw, 1.75rem);
     justify-items: center;
     text-align: center;
-    padding: clamp(1.75rem, 3vw, 2.5rem);
+    padding: clamp(2rem, 3vw, 2.75rem);
     border-radius: 0;
-    background: rgba(255, 255, 255, 0.92);
+    background: #ffffff;
     border: 1px solid var(--surface-border);
     box-shadow: var(--shadow-sm);
     overflow: hidden;
 }
 
-.objective-card::after {
-    content: "";
-    position: absolute;
-    inset: auto 0 0 0;
-    height: 6px;
-    background: linear-gradient(135deg, var(--color-primary), var(--color-secondary));
-    opacity: 0.72;
-}
-
 .objective-card__icon {
-    width: clamp(96px, 12vw, 128px);
-    height: clamp(96px, 12vw, 128px);
+    width: clamp(120px, 14vw, 168px);
+    height: clamp(120px, 14vw, 168px);
     display: grid;
     place-items: center;
     border-radius: 0;
-    background: rgba(218, 205, 233, 0.28);
-    border: 1px solid rgba(160, 122, 167, 0.32);
-    box-shadow: inset 0 10px 18px rgba(255, 255, 255, 0.45);
+    background: transparent;
+    border: none;
+    box-shadow: none;
+    overflow: hidden;
 }
 
 .objective-card__icon img {
-    width: clamp(64px, 8vw, 96px);
-    height: clamp(64px, 8vw, 96px);
+    width: 100%;
+    height: 100%;
     object-fit: contain;
-    filter: drop-shadow(0 10px 14px rgba(58, 106, 155, 0.18));
+    filter: none;
 }
 
 .objective-card__content {
     display: grid;
-    gap: 0.5rem;
+    gap: 0.75rem;
     justify-items: center;
+    max-width: 30ch;
 }
 
 .objective-card__title {
     margin: 0;
-    font-size: 1.2rem;
+    font-size: 1.35rem;
     color: var(--color-heading);
 }
 
 .objective-card__text {
     margin: 0;
     color: var(--color-muted);
-    font-size: 1rem;
-    max-width: 36ch;
+    font-size: 1.05rem;
 }
 
 @media (max-width: 680px) {

--- a/index.html
+++ b/index.html
@@ -61,7 +61,7 @@
             </div>
         </section>
 
-        <section class="section section--muted" aria-labelledby="goals-title">
+        <section class="section section--muted section--goals" aria-labelledby="goals-title">
             <div class="section__heading">
                 <h2 id="goals-title">Our Goals</h2>
                 <p>Three priorities guide how we translate consciousness research into meaningful impact.</p>
@@ -73,7 +73,7 @@
                     </div>
                     <div class="objective-card__content">
                         <h3 id="goal-neuro" class="objective-card__title">Awareness Atlas</h3>
-                        <p class="objective-card__text">Warping consciousness measures onto brain organization to create integrated map of the neural correlates</p>
+                        <p class="objective-card__text">Warping consciousness measures onto brain organization to create an integrated map of the neural correlates</p>
                     </div>
                 </article>
                 <article class="objective-card" role="listitem" aria-labelledby="goal-care">


### PR DESCRIPTION
## Summary
- add the goals section class in the markup so the intro copy spans the full heading width without early line breaks
- square the objective cards so the goal tiles have sharp corners again

## Testing
- No tests were run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e637ff917c832ba49a015d25444363