### PR TITLE
Adjust contact page layout and styles

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -727,7 +727,7 @@ a:focus {
 
 
 .contact-hero {
-    padding-block: clamp(3rem, 6vw, 5.5rem);
+    padding-block: clamp(2.5rem, 5vw, 4.5rem);
 }
 
 .contact-hero__container {
@@ -738,40 +738,58 @@ a:focus {
     gap: clamp(1.75rem, 4vw, 2.75rem);
 }
 
+.contact-hero__header {
+    display: grid;
+    gap: 0.75rem;
+    text-align: center;
+    max-width: min(760px, 100%);
+    margin-inline: auto;
+    color: var(--color-heading);
+}
+
+.contact-hero__header h1 {
+    margin: 0;
+    font-size: clamp(2rem, 3.1vw, 2.6rem);
+    color: var(--color-primary);
+    letter-spacing: -0.01em;
+}
+
+.contact-hero__header p {
+    margin: 0;
+    color: rgba(37, 38, 58, 0.78);
+    line-height: 1.6;
+}
+
+.contact-hero__content {
+    display: grid;
+    gap: clamp(1.75rem, 4vw, 2.5rem);
+    align-items: start;
+}
+
 @media (min-width: 960px) {
     .contact-hero__container {
-        grid-template-columns: minmax(0, 1.05fr) minmax(0, 1fr);
-        align-items: stretch;
+        gap: clamp(2rem, 4vw, 3rem);
+    }
+
+    .contact-hero__header {
+        text-align: left;
+        margin-inline: 0;
+    }
+
+    .contact-hero__content {
+        grid-template-columns: minmax(0, 1.05fr) minmax(0, 0.85fr);
     }
 }
 
 .contact-hero__info {
-    position: relative;
-    border-radius: 18px;
-    background: linear-gradient(135deg, rgba(246, 243, 251, 0.95), rgba(238, 234, 247, 0.92));
-    border: 1px solid rgba(58, 104, 153, 0.16);
-    box-shadow: 0 18px 35px rgba(62, 93, 150, 0.12);
     color: var(--color-heading);
 }
 
 .contact-hero__info-inner {
     display: grid;
-    gap: clamp(1.75rem, 3vw, 2.5rem);
-    padding: clamp(2rem, 5vw, 3.4rem);
-}
-
-.contact-hero__intro h1 {
-    margin: 0 0 0.75rem;
-    font-size: clamp(2rem, 3.2vw, 2.6rem);
-    color: var(--color-primary);
-    letter-spacing: -0.01em;
-}
-
-.contact-hero__intro p {
-    margin: 0;
-    max-width: 55ch;
-    color: rgba(37, 38, 58, 0.78);
-    line-height: 1.6;
+    gap: clamp(1.5rem, 3vw, 2.25rem);
+    padding-block: clamp(0.25rem, 1.5vw, 1.5rem);
+    padding-inline: clamp(0rem, 1.5vw, 0.75rem);
 }
 
 .contact-details {
@@ -817,13 +835,13 @@ a:focus {
     font-weight: 600;
     letter-spacing: 0.04em;
     text-transform: uppercase;
-    font-size: 0.75rem;
+    font-size: 0.8rem;
     color: rgba(37, 38, 58, 0.72);
 }
 
 .contact-detail__text a,
 .contact-detail__text address {
-    font-size: 1.05rem;
+    font-size: 1.12rem;
     font-style: normal;
     color: var(--color-heading);
     line-height: 1.5;
@@ -849,7 +867,7 @@ a:focus {
     color: rgba(37, 38, 58, 0.72);
     text-transform: uppercase;
     letter-spacing: 0.05em;
-    font-size: 0.75rem;
+    font-size: 0.82rem;
 }
 
 .contact-social__list {
@@ -1428,17 +1446,28 @@ a:focus {
 
 .contact-hero__form {
     position: relative;
-    border-radius: 24px;
+    border-radius: 22px;
     background: linear-gradient(140deg, rgba(58, 104, 153, 0.96), rgba(160, 122, 167, 0.92));
-    box-shadow: 0 24px 48px rgba(58, 104, 153, 0.28);
+    box-shadow: 0 20px 42px rgba(58, 104, 153, 0.25);
     overflow: hidden;
     color: #f9f7ff;
+    max-width: min(100%, 420px);
+}
+
+.contact-hero__content .contact-hero__form {
+    justify-self: center;
+}
+
+@media (min-width: 960px) {
+    .contact-hero__content .contact-hero__form {
+        justify-self: end;
+    }
 }
 
 .contact-hero__form-inner {
     display: grid;
-    gap: clamp(1.6rem, 3vw, 2.4rem);
-    padding: clamp(2.1rem, 4.6vw, 3.1rem);
+    gap: clamp(1.4rem, 3vw, 2.1rem);
+    padding: clamp(1.6rem, 4vw, 2.4rem);
     height: 100%;
 }
 
@@ -1456,9 +1485,9 @@ a:focus {
 
 .contact-hero__form-heading p {
     margin: 0;
-    color: rgba(249, 247, 255, 0.82);
-    font-size: 0.98rem;
-    line-height: 1.6;
+    color: rgba(249, 247, 255, 0.85);
+    font-size: 0.95rem;
+    line-height: 1.55;
 }
 
 .contact-form {
@@ -1476,6 +1505,10 @@ a:focus {
     font-weight: 600;
     color: var(--color-heading);
     font-size: 0.95rem;
+}
+
+.contact-hero__form .form-field label {
+    color: rgba(249, 247, 255, 0.9);
 }
 
 .form-field input,

--- a/contact.html
+++ b/contact.html
@@ -32,94 +32,96 @@
     <main>
         <section class="section contact-hero" aria-labelledby="contact-intro-title">
             <div class="contact-hero__container">
-                <div class="contact-hero__info">
-                    <div class="contact-hero__info-inner">
-                        <div class="contact-hero__intro">
-                            <h1 id="contact-intro-title">Get in touch</h1>
-                            <p>For inquiries regarding collaborations, partnerships, or general matters, reach out to us or arrange a meeting at our main office. We look forward to hearing from you.</p>
-                        </div>
-                        <ul class="contact-details" role="list">
-                            <li class="contact-detail" role="listitem">
-                                <span class="contact-detail__icon" aria-hidden="true">
-                                    <img src="assets/images/contact/icons/mail_icon.png" alt="">
-                                </span>
-                                <div class="contact-detail__text">
-                                    <span class="contact-detail__label">Email</span>
-                                    <a href="mailto:info@awarenet.org">info@awarenet.org</a>
+                <div class="contact-hero__header">
+                    <h1 id="contact-intro-title">Get in touch</h1>
+                    <p>For inquiries regarding collaborations, partnerships, or general matters, reach out to us or arrange a meeting at our main office. We look forward to hearing from you.</p>
+                </div>
+                <div class="contact-hero__content">
+                    <div class="contact-hero__info">
+                        <div class="contact-hero__info-inner">
+                            <ul class="contact-details" role="list">
+                                <li class="contact-detail" role="listitem">
+                                    <span class="contact-detail__icon" aria-hidden="true">
+                                        <img src="assets/images/contact/icons/mail_icon.png" alt="">
+                                    </span>
+                                    <div class="contact-detail__text">
+                                        <span class="contact-detail__label">Email</span>
+                                        <a href="mailto:info@awarenet.org">info@awarenet.org</a>
+                                    </div>
+                                </li>
+                                <li class="contact-detail" role="listitem">
+                                    <span class="contact-detail__icon" aria-hidden="true">
+                                        <img src="assets/images/contact/icons/office_phone_icon.png" alt="">
+                                    </span>
+                                    <div class="contact-detail__text">
+                                        <span class="contact-detail__label">Phone</span>
+                                        <a href="tel:+390497654321">+39 049 7654321</a>
+                                    </div>
+                                </li>
+                                <li class="contact-detail" role="listitem">
+                                    <span class="contact-detail__icon" aria-hidden="true">
+                                        <img src="assets/images/contact/icons/placeholder.png" alt="">
+                                    </span>
+                                    <div class="contact-detail__text">
+                                        <span class="contact-detail__label">Main office</span>
+                                        <address>Via Venezia 1<br>35131 Padova (PD), Italy</address>
+                                    </div>
+                                </li>
+                            </ul>
+                            <div class="contact-social" aria-label="AWARENET social media">
+                                <p class="contact-social__label">Follow us</p>
+                                <div class="contact-social__list">
+                                    <a class="contact-social__icon" href="#" aria-label="Visit our Facebook page">
+                                        <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+                                            <path d="M14.5 8.25h2V5h-2.35c-2.68 0-4.15 1.45-4.15 3.86v1.64H8v3.18h2v6.57h3.2v-6.57h2.73l.47-3.18H13.2V8.86c0-.43.14-.61 1.3-.61z" />
+                                        </svg>
+                                    </a>
+                                    <a class="contact-social__icon" href="#" aria-label="Visit our Twitter profile">
+                                        <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+                                            <path d="M20.5 6.62a6.2 6.2 0 0 1-1.77.49 3.08 3.08 0 0 0 1.36-1.7 6.16 6.16 0 0 1-1.95.75 3.07 3.07 0 0 0-5.23 2.1 3.2 3.2 0 0 0 .08.7A8.72 8.72 0 0 1 4.7 5.82a3.07 3.07 0 0 0-.42 1.54 3.07 3.07 0 0 0 1.37 2.56 3.06 3.06 0 0 1-1.39-.38v.04a3.08 3.08 0 0 0 2.46 3 3.08 3.08 0 0 1-1.38.05 3.08 3.08 0 0 0 2.87 2.14A6.17 6.17 0 0 1 4 16.45a8.7 8.7 0 0 0 4.71 1.38c5.65 0 8.74-4.69 8.74-8.74 0-.13 0-.26-.01-.39a6.27 6.27 0 0 0 1.56-1.61z" />
+                                        </svg>
+                                    </a>
+                                    <a class="contact-social__icon" href="#" aria-label="Visit our LinkedIn page">
+                                        <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+                                            <path d="M6.6 9.25h2.9v9.8H6.6zM8.1 5.5a1.7 1.7 0 1 1 0 3.4 1.7 1.7 0 0 1 0-3.4zm4.1 3.75h2.77v1.34h.04c.39-.74 1.35-1.52 2.78-1.52 2.97 0 3.52 1.96 3.52 4.5v5.48h-2.9v-4.86c0-1.16-.02-2.65-1.62-2.65-1.63 0-1.88 1.27-1.88 2.57v4.94H12.2z" />
+                                        </svg>
+                                    </a>
+                                    <a class="contact-social__icon" href="#" aria-label="Visit our Instagram profile">
+                                        <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+                                            <path d="M16.8 4H7.2A3.2 3.2 0 0 0 4 7.2v9.6A3.2 3.2 0 0 0 7.2 20h9.6a3.2 3.2 0 0 0 3.2-3.2V7.2A3.2 3.2 0 0 0 16.8 4zm-4.8 11.56a3.36 3.36 0 1 1 0-6.72 3.36 3.36 0 0 1 0 6.72zm4.9-6.88a.96.96 0 1 1 0-1.92.96.96 0 0 1 0 1.92zM12 9.52a2.48 2.48 0 1 0 0 4.96 2.48 2.48 0 0 0 0-4.96z" />
+                                        </svg>
+                                    </a>
                                 </div>
-                            </li>
-                            <li class="contact-detail" role="listitem">
-                                <span class="contact-detail__icon" aria-hidden="true">
-                                    <img src="assets/images/contact/icons/office_phone_icon.png" alt="">
-                                </span>
-                                <div class="contact-detail__text">
-                                    <span class="contact-detail__label">Phone</span>
-                                    <a href="tel:+390497654321">+39 049 7654321</a>
-                                </div>
-                            </li>
-                            <li class="contact-detail" role="listitem">
-                                <span class="contact-detail__icon" aria-hidden="true">
-                                    <img src="assets/images/contact/icons/placeholder.png" alt="">
-                                </span>
-                                <div class="contact-detail__text">
-                                    <span class="contact-detail__label">Main office</span>
-                                    <address>Via Venezia 1<br>35131 Padova (PD), Italy</address>
-                                </div>
-                            </li>
-                        </ul>
-                        <div class="contact-social" aria-label="AWARENET social media">
-                            <p class="contact-social__label">Follow us</p>
-                            <div class="contact-social__list">
-                                <a class="contact-social__icon" href="#" aria-label="Visit our Facebook page">
-                                    <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
-                                        <path d="M14.5 8.25h2V5h-2.35c-2.68 0-4.15 1.45-4.15 3.86v1.64H8v3.18h2v6.57h3.2v-6.57h2.73l.47-3.18H13.2V8.86c0-.43.14-.61 1.3-.61z" />
-                                    </svg>
-                                </a>
-                                <a class="contact-social__icon" href="#" aria-label="Visit our Twitter profile">
-                                    <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
-                                        <path d="M20.5 6.62a6.2 6.2 0 0 1-1.77.49 3.08 3.08 0 0 0 1.36-1.7 6.16 6.16 0 0 1-1.95.75 3.07 3.07 0 0 0-5.23 2.1 3.2 3.2 0 0 0 .08.7A8.72 8.72 0 0 1 4.7 5.82a3.07 3.07 0 0 0-.42 1.54 3.07 3.07 0 0 0 1.37 2.56 3.06 3.06 0 0 1-1.39-.38v.04a3.08 3.08 0 0 0 2.46 3 3.08 3.08 0 0 1-1.38.05 3.08 3.08 0 0 0 2.87 2.14A6.17 6.17 0 0 1 4 16.45a8.7 8.7 0 0 0 4.71 1.38c5.65 0 8.74-4.69 8.74-8.74 0-.13 0-.26-.01-.39a6.27 6.27 0 0 0 1.56-1.61z" />
-                                    </svg>
-                                </a>
-                                <a class="contact-social__icon" href="#" aria-label="Visit our LinkedIn page">
-                                    <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
-                                        <path d="M6.6 9.25h2.9v9.8H6.6zM8.1 5.5a1.7 1.7 0 1 1 0 3.4 1.7 1.7 0 0 1 0-3.4zm4.1 3.75h2.77v1.34h.04c.39-.74 1.35-1.52 2.78-1.52 2.97 0 3.52 1.96 3.52 4.5v5.48h-2.9v-4.86c0-1.16-.02-2.65-1.62-2.65-1.63 0-1.88 1.27-1.88 2.57v4.94H12.2z" />
-                                    </svg>
-                                </a>
-                                <a class="contact-social__icon" href="#" aria-label="Visit our Instagram profile">
-                                    <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
-                                        <path d="M16.8 4H7.2A3.2 3.2 0 0 0 4 7.2v9.6A3.2 3.2 0 0 0 7.2 20h9.6a3.2 3.2 0 0 0 3.2-3.2V7.2A3.2 3.2 0 0 0 16.8 4zm-4.8 11.56a3.36 3.36 0 1 1 0-6.72 3.36 3.36 0 0 1 0 6.72zm4.9-6.88a.96.96 0 1 1 0-1.92.96.96 0 0 1 0 1.92zM12 9.52a2.48 2.48 0 1 0 0 4.96 2.48 2.48 0 0 0 0-4.96z" />
-                                    </svg>
-                                </a>
                             </div>
                         </div>
                     </div>
-                </div>
-                <div class="contact-hero__form" aria-labelledby="contact-form-title">
-                    <div class="contact-hero__form-inner">
-                        <div class="contact-hero__form-heading">
-                            <h2 id="contact-form-title">Send us a message</h2>
-                            <p>Fill out the form and we will get back to you as soon as possible.</p>
+                    <div class="contact-hero__form" aria-labelledby="contact-form-title">
+                        <div class="contact-hero__form-inner">
+                            <div class="contact-hero__form-heading">
+                                <h2 id="contact-form-title">Send us a message</h2>
+                                <p>Fill out the form and we will get back to you as soon as possible.</p>
+                            </div>
+                            <form class="contact-form" aria-label="Contact form" data-contact-form data-contact-email="contact@awarenet.org">
+                                <div class="form-field">
+                                    <label for="contact-name">Name</label>
+                                    <input type="text" id="contact-name" name="name" placeholder="Your name" required>
+                                </div>
+                                <div class="form-field">
+                                    <label for="contact-email">Email</label>
+                                    <input type="email" id="contact-email" name="email" placeholder="name@company.com" required>
+                                </div>
+                                <div class="form-field">
+                                    <label for="contact-subject">Subject</label>
+                                    <input type="text" id="contact-subject" name="subject" placeholder="How can we help?" required>
+                                </div>
+                                <div class="form-field">
+                                    <label for="contact-message">Message</label>
+                                    <textarea id="contact-message" name="message" rows="4" placeholder="Share your message" required></textarea>
+                                </div>
+                                <button type="submit" class="button">Send request</button>
+                                <p class="form-status" data-form-status role="status" aria-live="polite"></p>
+                            </form>
                         </div>
-                        <form class="contact-form" aria-label="Contact form" data-contact-form data-contact-email="contact@awarenet.org">
-                            <div class="form-field">
-                                <label for="contact-name">Name</label>
-                                <input type="text" id="contact-name" name="name" placeholder="Your name" required>
-                            </div>
-                            <div class="form-field">
-                                <label for="contact-email">Email</label>
-                                <input type="email" id="contact-email" name="email" placeholder="name@company.com" required>
-                            </div>
-                            <div class="form-field">
-                                <label for="contact-subject">Subject</label>
-                                <input type="text" id="contact-subject" name="subject" placeholder="How can we help?" required>
-                            </div>
-                            <div class="form-field">
-                                <label for="contact-message">Message</label>
-                                <textarea id="contact-message" name="message" rows="4" placeholder="Share your message" required></textarea>
-                            </div>
-                            <button type="submit" class="button">Send request</button>
-                            <p class="form-status" data-form-status role="status" aria-live="polite"></p>
-                        </form>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
## Summary
- move the "Get in touch" heading out of the info column and share it across the contact section
- simplify the contact details area styling, enlarge typography, and right-size the message form card
- tweak spacing so the contact hero content fits comfortably within a single viewport

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e640062e74832b9c47732999b8b2cb