### PR TITLE
Square corners on news cards

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -1084,14 +1084,14 @@ a:focus {
     padding: 0.85rem;
     background: rgba(245, 246, 255, 0.9);
     border: 1px solid var(--card-border);
-    border-radius: 16px;
+    border-radius: 0;
     box-shadow: var(--shadow-sm);
 }
 
 .news-card__media {
     width: 100%;
     aspect-ratio: 3 / 2;
-    border-radius: 12px;
+    border-radius: 0;
     overflow: hidden;
     background: var(--card-fill);
     display: flex;


### PR DESCRIPTION
## Summary
- remove rounded corners from news archive cards to achieve sharper styling
- square off news card media frames for consistent edge treatment

## Testing
- no automated tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68e6402722a8832ba95d99ec5ddd8e6d