### PR TITLE
Adjust team photo aspect ratio

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -1301,7 +1301,7 @@ a:focus {
 }
 
 .team-card__photo {
-    aspect-ratio: 3 / 4;
+    aspect-ratio: 1 / 1;
     display: grid;
     place-items: center;
     background: #e3e7f1;


### PR DESCRIPTION
## Summary
- reduce the team card photo aspect ratio to make the portraits less tall

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68e6404c2c94832b89f1d880bb676324