### PR TITLE
Remove drop shadows from homepage cards

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -622,7 +622,7 @@ a:focus {
     border-radius: 0;
     background: #ffffff;
     border: 1px solid var(--surface-border);
-    box-shadow: var(--shadow-sm);
+    box-shadow: none;
     overflow: hidden;
 }
 
@@ -676,12 +676,12 @@ a:focus {
     gap: clamp(1.5rem, 3vw, 2.5rem);
 }
 
-.card { 
+.card {
     background: var(--card-fill);
     border: 1px solid var(--card-border);
     border-radius: 0;
     padding: 2rem;
-    box-shadow: var(--shadow-sm);
+    box-shadow: none;
 }
 
 .card h3,


### PR DESCRIPTION
## Summary
- remove the drop shadows from the homepage cards and objectives to achieve a flatter look

## Testing
- no tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68e6406183d8832bb0bed4c60b0e70f8