### PR TITLE
Wrap goals section in single card

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -605,23 +605,31 @@ a:focus {
     max-width: none;
 }
 
-.objectives-grid {
+.objectives-card {
+    background: #ffffff;
+    border: 1px solid var(--surface-border);
+    border-radius: 0;
+    padding: clamp(2.25rem, 4vw, 3rem);
+    box-shadow: none;
+}
+
+.objectives-card__list {
     display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
     gap: clamp(1.75rem, 3.5vw, 3rem);
 }
 
-.objective-card {
+.objective-card__item {
     position: relative;
     display: grid;
     grid-template-columns: 1fr;
     gap: clamp(1.25rem, 2.5vw, 1.75rem);
     justify-items: center;
     text-align: center;
-    padding: clamp(2rem, 3vw, 2.75rem);
+    padding: clamp(1.5rem, 3vw, 2rem);
     border-radius: 0;
-    background: #ffffff;
-    border: 1px solid var(--surface-border);
+    background: transparent;
+    border: none;
     box-shadow: none;
     overflow: hidden;
 }
@@ -665,7 +673,7 @@ a:focus {
 }
 
 @media (max-width: 680px) {
-    .objective-card {
+    .objective-card__item {
         padding: 1.5rem;
     }
 }

--- a/index.html
+++ b/index.html
@@ -66,34 +66,36 @@
                 <h2 id="goals-title">Our Goals</h2>
                 <p>Three priorities guide how we translate consciousness research into meaningful impact.</p>
             </div>
-            <div class="objectives-grid" role="list">
-                <article class="objective-card" role="listitem" aria-labelledby="goal-neuro">
-                    <div class="objective-card__icon" aria-hidden="true">
-                        <img src="assets/images/home/goals/brain.jpeg" alt="" loading="lazy">
-                    </div>
-                    <div class="objective-card__content">
-                        <h3 id="goal-neuro" class="objective-card__title">Awareness Atlas</h3>
-                        <p class="objective-card__text">Warping consciousness measures onto brain organization to create an integrated map of the neural correlates</p>
-                    </div>
-                </article>
-                <article class="objective-card" role="listitem" aria-labelledby="goal-care">
-                    <div class="objective-card__icon" aria-hidden="true">
-                        <img src="assets/images/home/goals/prediciteve.jpg" alt="" loading="lazy">
-                    </div>
-                    <div class="objective-card__content">
-                        <h3 id="goal-care" class="objective-card__title">Predictive Models</h3>
-                        <p class="objective-card__text">Identifying how brain lesions impact consciousness</p>
-                    </div>
-                </article>
-                <article class="objective-card" role="listitem" aria-labelledby="goal-insights">
-                    <div class="objective-card__icon" aria-hidden="true">
-                        <img src="assets/images/home/goals/doctors.png" alt="" loading="lazy">
-                    </div>
-                    <div class="objective-card__content">
-                        <h3 id="goal-insights" class="objective-card__title">Bench to Bedside</h3>
-                        <p class="objective-card__text">Develop tools to assess and address disorders of consciousness</p>
-                    </div>
-                </article>
+            <div class="objectives-card" role="group" aria-labelledby="goals-title">
+                <div class="objectives-card__list" role="list">
+                    <article class="objective-card__item" role="listitem" aria-labelledby="goal-neuro">
+                        <div class="objective-card__icon" aria-hidden="true">
+                            <img src="assets/images/home/goals/brain.jpeg" alt="" loading="lazy">
+                        </div>
+                        <div class="objective-card__content">
+                            <h3 id="goal-neuro" class="objective-card__title">Awareness Atlas</h3>
+                            <p class="objective-card__text">Warping consciousness measures onto brain organization to create an integrated map of the neural correlates</p>
+                        </div>
+                    </article>
+                    <article class="objective-card__item" role="listitem" aria-labelledby="goal-care">
+                        <div class="objective-card__icon" aria-hidden="true">
+                            <img src="assets/images/home/goals/prediciteve.jpg" alt="" loading="lazy">
+                        </div>
+                        <div class="objective-card__content">
+                            <h3 id="goal-care" class="objective-card__title">Predictive Models</h3>
+                            <p class="objective-card__text">Identifying how brain lesions impact consciousness</p>
+                        </div>
+                    </article>
+                    <article class="objective-card__item" role="listitem" aria-labelledby="goal-insights">
+                        <div class="objective-card__icon" aria-hidden="true">
+                            <img src="assets/images/home/goals/doctors.png" alt="" loading="lazy">
+                        </div>
+                        <div class="objective-card__content">
+                            <h3 id="goal-insights" class="objective-card__title">Bench to Bedside</h3>
+                            <p class="objective-card__text">Develop tools to assess and address disorders of consciousness</p>
+                        </div>
+                    </article>
+                </div>
             </div>
         </section>
 


### PR DESCRIPTION
## Summary
- wrap the "Our Goals" content in a single white card container
- adjust the goal item markup and styles to fit inside the unified card layout

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e65a1903c0832b8b75ab52ba3a60cc