### PR TITLE
Adjust contact hero typography

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -750,22 +750,23 @@ a:focus {
     display: grid;
     gap: 0.75rem;
     text-align: center;
-    max-width: min(760px, 100%);
+    max-width: 100%;
     margin-inline: auto;
     color: var(--color-heading);
 }
 
 .contact-hero__header h1 {
     margin: 0;
-    font-size: clamp(2rem, 3.1vw, 2.6rem);
-    color: var(--color-primary);
+    font-size: clamp(1.75rem, 2.8vw, 2.25rem);
+    color: var(--color-heading);
     letter-spacing: -0.01em;
 }
 
 .contact-hero__header p {
     margin: 0;
-    color: rgba(37, 38, 58, 0.78);
+    color: rgba(37, 38, 58, 0.85);
     line-height: 1.6;
+    font-size: clamp(1.05rem, 2vw, 1.35rem);
 }
 
 .contact-hero__content {


### PR DESCRIPTION
## Summary
- reduce the "Get in touch" heading size and align its color with other section headings
- enlarge the introductory paragraph and allow it to span the full width of the contact hero header

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e65ed6c4c0832bbc6104e737d868ef