### PR TITLE
Match contact detail icons with social icon styling

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -825,15 +825,13 @@ a:focus {
     width: 3.5rem;
     height: 3.5rem;
     border-radius: 50%;
-    background: transparent;
-    border: none;
-    box-shadow: none;
+    color: var(--color-primary);
 }
 
-.contact-detail__icon img {
+.contact-detail__icon svg {
     width: 70%;
     height: 70%;
-    object-fit: contain;
+    fill: currentColor;
 }
 
 

--- a/contact.html
+++ b/contact.html
@@ -42,7 +42,9 @@
                             <ul class="contact-details" role="list">
                                 <li class="contact-detail" role="listitem">
                                     <span class="contact-detail__icon" aria-hidden="true">
-                                        <img src="assets/images/contact/icons/mail_icon.png" alt="">
+                                        <svg viewBox="0 0 24 24" focusable="false">
+                                            <path d="M4 5h16a2 2 0 0 1 2 2v10a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V7a2 2 0 0 1 2-2zm0 2v.2l8 5 8-5V7H4zm16 10V9.3l-8 5-8-5V17a1 1 0 0 0 1 1h14a1 1 0 0 0 1-1z" />
+                                        </svg>
                                     </span>
                                     <div class="contact-detail__text">
                                         <span class="contact-detail__label">Email</span>
@@ -51,7 +53,9 @@
                                 </li>
                                 <li class="contact-detail" role="listitem">
                                     <span class="contact-detail__icon" aria-hidden="true">
-                                        <img src="assets/images/contact/icons/office_phone_icon.png" alt="">
+                                        <svg viewBox="0 0 24 24" focusable="false">
+                                            <path d="M7.4 2h2.2c.5 0 .9.3 1 .8l.7 3.1a1 1 0 0 1-.3.9L9.6 8.7a10.5 10.5 0 0 0 5.7 5.7l1.9-1.4a1 1 0 0 1 .9-.2l3.1.7c.5.1.8.5.8 1v2.2c0 .6-.5 1.1-1.1 1.1C14.8 18.1 5.9 9.2 6.3 3.1 6.4 2.5 6.9 2 7.4 2z" />
+                                        </svg>
                                     </span>
                                     <div class="contact-detail__text">
                                         <span class="contact-detail__label">Phone</span>
@@ -60,7 +64,9 @@
                                 </li>
                                 <li class="contact-detail" role="listitem">
                                     <span class="contact-detail__icon" aria-hidden="true">
-                                        <img src="assets/images/contact/icons/placeholder.png" alt="">
+                                        <svg viewBox="0 0 24 24" focusable="false">
+                                            <path d="M12 2a7 7 0 0 0-7 7c0 5.25 7 13 7 13s7-7.75 7-13a7 7 0 0 0-7-7zm0 9.5a2.5 2.5 0 1 1 0-5 2.5 2.5 0 0 1 0 5z" />
+                                        </svg>
                                     </span>
                                     <div class="contact-detail__text">
                                         <span class="contact-detail__label">Main office</span>


### PR DESCRIPTION
## Summary
- replace the contact detail PNG images with inline SVG icons that align with the social icon styling
- update contact icon styling to inherit the theme primary color for a consistent appearance

## Testing
- not run (static changes)

------
https://chatgpt.com/codex/tasks/task_e_68e65f4b7ca0832b9a12573a2debb06b