### PR TITLE
Restore university selector on contact page

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -1466,7 +1466,7 @@ a:focus {
     box-shadow: 0 20px 42px rgba(58, 104, 153, 0.25);
     overflow: hidden;
     color: #f9f7ff;
-    max-width: min(100%, 420px);
+    max-width: min(100%, 480px);
 }
 
 .contact-hero__content .contact-hero__form {
@@ -1481,8 +1481,8 @@ a:focus {
 
 .contact-hero__form-inner {
     display: grid;
-    gap: clamp(1.4rem, 3vw, 2.1rem);
-    padding: clamp(1.6rem, 4vw, 2.4rem);
+    gap: clamp(1.1rem, 2.6vw, 1.8rem);
+    padding: clamp(1.4rem, 3.6vw, 2rem);
     height: 100%;
 }
 
@@ -1502,7 +1502,7 @@ a:focus {
     margin: 0;
     color: rgba(249, 247, 255, 0.85);
     font-size: 0.95rem;
-    line-height: 1.55;
+    line-height: 1.45;
 }
 
 .contact-form {
@@ -1526,6 +1526,19 @@ a:focus {
     color: rgba(249, 247, 255, 0.9);
 }
 
+.contact-hero__form .organization-select__toggle {
+    color: rgba(249, 247, 255, 0.75);
+}
+
+.contact-hero__form .organization-select__toggle:hover,
+.contact-hero__form .organization-select__toggle:focus-visible {
+    color: #ffffff;
+}
+
+.contact-hero__form .organization-select__list {
+    border-radius: 10px;
+}
+
 .form-field input,
 .form-field textarea {
     border: 1px solid rgba(58, 104, 153, 0.16);
@@ -1535,6 +1548,91 @@ a:focus {
     background: var(--color-background);
     color: var(--color-text);
     line-height: 1.4;
+}
+
+.organization-select {
+    position: relative;
+    display: flex;
+    align-items: center;
+    width: 100%;
+}
+
+.organization-select input[data-organization-input] {
+    flex: 1;
+    padding-right: 2.5rem;
+}
+
+.organization-select__toggle {
+    position: absolute;
+    top: 50%;
+    right: 0.65rem;
+    transform: translateY(-50%);
+    border: none;
+    background: transparent;
+    color: var(--color-muted);
+    cursor: pointer;
+    font-size: 0.95rem;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding: 0.15rem;
+}
+
+.organization-select__toggle:focus-visible {
+    outline: 2px solid var(--focus-outline);
+    border-radius: 6px;
+}
+
+.organization-select__list {
+    position: absolute;
+    top: calc(100% + 0.4rem);
+    left: 0;
+    right: 0;
+    background: #ffffff;
+    border: 1px solid var(--surface-border);
+    border-radius: 12px;
+    box-shadow: 0 18px 35px rgba(64, 89, 142, 0.18);
+    max-height: 18rem;
+    overflow-y: auto;
+    padding: 0.4rem 0;
+    display: none;
+    z-index: 12;
+}
+
+.contact-page .organization-select__toggle:focus-visible {
+    border-radius: 0;
+}
+
+.contact-page .organization-select__list {
+    border-radius: 0;
+}
+
+.organization-select--open .organization-select__list {
+    display: block;
+}
+
+.organization-select__option {
+    width: 100%;
+    text-align: left;
+    border: none;
+    background: transparent;
+    padding: 0.55rem 1rem;
+    font: inherit;
+    color: var(--color-text);
+    cursor: pointer;
+    transition: background-color 0.2s ease;
+}
+
+.organization-select__option:hover,
+.organization-select__option:focus {
+    background-color: rgba(73, 94, 152, 0.08);
+    outline: none;
+}
+
+.organization-select__empty {
+    padding: 0.7rem 1rem;
+    color: var(--color-muted);
+    font-size: 0.95rem;
 }
 
 .form-field input:focus,

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -461,6 +461,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
     const contactForm = document.querySelector('[data-contact-form]');
     if (contactForm) {
+        setupOrganizationSelector(contactForm);
         const statusMessage = contactForm.querySelector('[data-form-status]');
         const contactEmail = (contactForm.dataset.contactEmail || '').trim();
 
@@ -495,7 +496,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
             const name = getValue('name');
             const email = getValue('email');
-            const subjectValue = getValue('subject');
+            const organization = getValue('organization');
             const message = getValue('message');
 
             const emailLines = [
@@ -503,13 +504,13 @@ document.addEventListener('DOMContentLoaded', () => {
                 '',
                 `Name: ${name || 'Not provided'}`,
                 `Email: ${email || 'Not provided'}`,
-                `Subject: ${subjectValue || 'General inquiry'}`,
+                `University: ${organization || 'Not provided'}`,
                 '',
                 'Message:',
                 message || 'No message provided.'
             ];
 
-            const subject = encodeURIComponent(subjectValue || `New contact request from ${name || 'AWARENET website'}`);
+            const subject = encodeURIComponent(`New contact request from ${name || organization || 'AWARENET website'}`);
             const body = encodeURIComponent(emailLines.join('\n'));
             const mailtoLink = `mailto:${contactEmail}?subject=${subject}&body=${body}`;
 

--- a/contact.html
+++ b/contact.html
@@ -110,13 +110,19 @@
                                     <label for="contact-email">Email</label>
                                     <input type="email" id="contact-email" name="email" placeholder="name@company.com" required>
                                 </div>
-                                <div class="form-field">
-                                    <label for="contact-subject">Subject</label>
-                                    <input type="text" id="contact-subject" name="subject" placeholder="How can we help?" required>
+                                <div class="form-field form-field--organization" data-organization-field>
+                                    <label for="contact-organization">University</label>
+                                    <div class="organization-select" data-organization-select>
+                                        <input type="text" id="contact-organization" name="organization" placeholder="Start typing to find your institution" autocomplete="off" data-organization-input aria-autocomplete="list" aria-expanded="false" aria-controls="organization-options" role="combobox">
+                                        <button type="button" class="organization-select__toggle" aria-label="Toggle organization list" aria-haspopup="listbox" aria-expanded="false" data-organization-toggle>
+                                            <span aria-hidden="true">&#9662;</span>
+                                        </button>
+                                        <div class="organization-select__list" id="organization-options" role="listbox" data-organization-list></div>
+                                    </div>
                                 </div>
                                 <div class="form-field">
                                     <label for="contact-message">Message</label>
-                                    <textarea id="contact-message" name="message" rows="4" placeholder="Share your message" required></textarea>
+                                    <textarea id="contact-message" name="message" rows="3" placeholder="Share your message" required></textarea>
                                 </div>
                                 <button type="submit" class="button">Send request</button>
                                 <p class="form-status" data-form-status role="status" aria-live="polite"></p>


### PR DESCRIPTION
## Summary
- remove the subject field and bring back the university selector on the contact form, wiring it up to the existing autocomplete logic
- widen the form card and tighten spacing so the intro copy stays on one line

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68e65f1c4e84832b877cb5e175e33272