### PR TITLE
Adjust CTA spacing

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -704,6 +704,7 @@ a:focus {
     display: grid;
     gap: clamp(1.75rem, 4vw, 2.75rem);
     justify-items: center;
+    padding-bottom: clamp(5rem, 12vw, 8rem);
 }
 
 .section--cta .section__heading {


### PR DESCRIPTION
## Summary
- increase bottom padding on the homepage call-to-action section to create more space beneath the Contact Us button

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e65f905414832b80944f5a0ae04cee