### PR TITLE
Remove eyebrow label from about section

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -678,26 +678,107 @@ a:focus {
     }
 }
 
-.card-grid {
+.section--about {
+    position: relative;
+}
+
+.about-layout {
     display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
-    gap: clamp(1.5rem, 3vw, 2.5rem);
+    gap: clamp(1.75rem, 4vw, 3rem);
+    align-items: start;
 }
 
-.card {
-    background: var(--card-fill);
-    border: 1px solid var(--card-border);
-    border-radius: 0;
-    padding: 2rem;
-    box-shadow: none;
+@media (min-width: 860px) {
+    .about-layout {
+        grid-template-columns: minmax(0, 1.05fr) minmax(0, 0.95fr);
+        gap: clamp(2rem, 5vw, 4rem);
+    }
 }
 
-.card h3,
-.card h2 {
+.about-layout__intro {
+    display: grid;
+    gap: clamp(0.75rem, 2vw, 1.25rem);
+    padding-block: clamp(1rem, 3vw, 1.75rem);
+}
+
+.about-layout__intro h2 {
     margin-top: 0;
-    margin-bottom: 0.75rem;
-    font-size: 1.45rem;
+    margin-bottom: 1rem;
     color: var(--color-heading);
+}
+
+.about-layout__intro p {
+    margin: 0;
+    max-width: 48ch;
+    color: var(--color-muted);
+}
+
+.about-layout__highlights {
+    display: grid;
+    gap: clamp(1.25rem, 3vw, 2.25rem);
+}
+
+.about-highlight {
+    position: relative;
+    display: grid;
+    grid-template-columns: auto 1fr;
+    align-items: start;
+    gap: clamp(1rem, 2vw, 1.5rem);
+}
+
+.about-highlight__accent {
+    width: clamp(0.85rem, 2vw, 1.1rem);
+    height: 100%;
+    background: linear-gradient(180deg, var(--color-primary), rgba(58, 106, 155, 0.2));
+    border-radius: 999px;
+}
+
+.about-highlight__content {
+    display: grid;
+    gap: 0.65rem;
+    padding-bottom: clamp(0.5rem, 1vw, 0.75rem);
+    border-bottom: 1px solid rgba(58, 106, 155, 0.18);
+}
+
+.about-highlight:last-child .about-highlight__content {
+    border-bottom: 0;
+}
+
+.about-highlight--offset {
+    transform: translateY(clamp(0rem, 1.5vw, 0.75rem));
+}
+
+.about-highlight h3 {
+    margin: 0;
+    font-size: 1.35rem;
+    color: var(--color-heading);
+}
+
+.about-highlight p {
+    margin: 0;
+    color: var(--color-muted);
+    font-size: 1.05rem;
+}
+
+.about-highlight__link {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.45rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: var(--color-primary);
+    font-size: 0.92rem;
+}
+
+.about-highlight__link::after {
+    content: "\2192";
+    transition: transform 0.2s ease;
+}
+
+.about-highlight__link:hover::after,
+.about-highlight__link:focus::after {
+    transform: translateX(0.35rem);
 }
 
 .section--cta {

--- a/index.html
+++ b/index.html
@@ -43,21 +43,29 @@
         </section>
 
         <section class="section section--surface section--about" aria-labelledby="about-title">
-            <div class="section__heading">
-                <h2 id="about-title">What is AWARENET?</h2>
-                <p>AWARENET maps how the brain generates and organizes consciousness, combining intracranial recordings, brain imaging, and computational modeling to link neural activity with clinical outcomes.</p>
-            </div>
-            <div class="card-grid">
-                <article class="card" aria-labelledby="about-research">
-                    <h3 id="about-research">What we do?</h3>
-                    <p>A single map to understand how the brain generates and organizes consciousness.</p>
-                    <a class="button button--secondary" href="research.html">Explore our Research</a>
-                </article>
-                <article class="card" aria-labelledby="about-team">
-                    <h3 id="about-team">An extended network</h3>
-                    <p>AWARENET brings together Italy’s leading minds in systems and clinical neuroscience.</p>
-                    <a class="button button--secondary" href="team.html">Meet the Team</a>
-                </article>
+            <div class="about-layout">
+                <div class="about-layout__intro">
+                    <h2 id="about-title">What is AWARENET?</h2>
+                    <p>AWARENET maps how the brain generates and organizes consciousness, combining intracranial recordings, brain imaging, and computational modeling to link neural activity with clinical outcomes.</p>
+                </div>
+                <div class="about-layout__highlights" role="list">
+                    <article class="about-highlight" aria-labelledby="about-research" role="listitem">
+                        <div class="about-highlight__accent" aria-hidden="true"></div>
+                        <div class="about-highlight__content">
+                            <h3 id="about-research">What we do</h3>
+                            <p>A single map to understand how the brain generates and organizes consciousness.</p>
+                            <a class="about-highlight__link" href="research.html">Explore our Research</a>
+                        </div>
+                    </article>
+                    <article class="about-highlight about-highlight--offset" aria-labelledby="about-team" role="listitem">
+                        <div class="about-highlight__accent" aria-hidden="true"></div>
+                        <div class="about-highlight__content">
+                            <h3 id="about-team">An extended network</h3>
+                            <p>AWARENET brings together Italy’s leading minds in systems and clinical neuroscience.</p>
+                            <a class="about-highlight__link" href="team.html">Meet the Team</a>
+                        </div>
+                    </article>
+                </div>
             </div>
         </section>
 


### PR DESCRIPTION
## Summary
- remove the ABOUT eyebrow label from the about intro copy and rely on the heading for context
- tidy the intro heading spacing now that the eyebrow label is gone

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e66014bb20832b945faa901d8cbc6a