### PR TITLE
Align contact hero typography with site headings

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -800,16 +800,16 @@ a:focus {
 
 .contact-hero__header h1 {
     margin: 0;
-    font-size: clamp(1.75rem, 2.8vw, 2.25rem);
+    font-size: calc(clamp(1.83rem, 4.2vw, 2.73rem) - 2pt);
     color: var(--color-heading);
     letter-spacing: -0.01em;
 }
 
 .contact-hero__header p {
     margin: 0;
-    color: rgba(37, 38, 58, 0.85);
+    color: var(--color-muted);
     line-height: 1.6;
-    font-size: clamp(1.05rem, 2vw, 1.35rem);
+    font-size: clamp(1.1rem, 2.2vw, 1.25rem);
 }
 
 .contact-hero__content {


### PR DESCRIPTION
## Summary
- match the "Get in touch" heading size with the global section heading scale
- tone the contact hero blurb color to the shared muted tone and resize it between other hero descriptions

## Testing
- no tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68e665ca0324832b92f4c78e1566db60