### PR TITLE
Adjust contact layout for single-screen view

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -899,6 +899,47 @@ a:focus {
     align-items: start;
 }
 
+@media (min-width: 720px) {
+    .contact-hero__info-inner {
+        justify-items: start;
+        text-align: left;
+        align-content: start;
+        gap: clamp(1.75rem, 3vw, 2.5rem);
+    }
+
+    .contact-details {
+        justify-items: start;
+    }
+
+    .contact-detail {
+        grid-template-columns: auto 1fr;
+        gap: 0.75rem 1rem;
+        justify-items: start;
+        text-align: left;
+        align-items: start;
+    }
+
+    .contact-detail__text {
+        text-align: left;
+    }
+
+    .contact-detail__icon {
+        align-self: start;
+    }
+
+    .contact-social {
+        justify-items: start;
+    }
+
+    .contact-social__label {
+        text-align: left;
+    }
+
+    .contact-social__list {
+        justify-content: flex-start;
+    }
+}
+
 @media (min-width: 960px) {
     .contact-hero__container {
         gap: clamp(2rem, 4vw, 3rem);
@@ -911,6 +952,46 @@ a:focus {
 
     .contact-hero__content {
         grid-template-columns: minmax(0, 1.05fr) minmax(0, 0.85fr);
+    }
+}
+
+@media (min-width: 1100px) {
+    .contact-hero__container {
+        grid-template-columns: minmax(0, 1.05fr) minmax(0, 0.9fr);
+        grid-auto-rows: min-content;
+        align-items: stretch;
+    }
+
+    .contact-hero__header {
+        max-width: 32rem;
+        align-self: end;
+    }
+
+    .contact-hero__content {
+        display: contents;
+    }
+
+    .contact-hero__info {
+        grid-column: 1 / 2;
+        grid-row: 2;
+        align-self: start;
+    }
+
+    .contact-hero__info-inner {
+        max-width: 32rem;
+        margin: 0;
+    }
+
+    .contact-hero__form {
+        grid-column: 2 / 3;
+        grid-row: 1 / span 2;
+        justify-self: stretch;
+        align-self: stretch;
+        max-width: 440px;
+    }
+
+    .contact-hero__form-inner {
+        height: 100%;
     }
 }
 


### PR DESCRIPTION
## Summary
- realign the contact information section to left-align content on wider screens while preserving mobile layout
- reorganize the contact hero grid to place the form alongside the details and stretch it for balanced spacing

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e66ba7aa94832b851567e7cdeb2455