### PR TITLE
Align team heading color with partner hero

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -1414,6 +1414,8 @@ a:focus {
     margin-inline: auto;
 }
 
+#institutions-title,
+#team-title,
 .team-section--calm .section__heading h2 {
     color: #1b2c4d;
 }


### PR DESCRIPTION
## Summary
- ensure the team section heading uses the same deep blue color as the partner institutions hero title
- reuse the heading color rule for both partner and team section titles for consistent styling

## Testing
- no automated tests were run (static HTML/CSS change)


------
https://chatgpt.com/codex/tasks/task_e_68e66c969f58832bbb7a64b963bd3624