### PR TITLE
Increase highlights intro text size

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -638,6 +638,14 @@ a:focus {
     font-size: 1.05rem;
 }
 
+.highlights .section__heading {
+    max-width: 100%;
+}
+
+.highlights .section__heading p {
+    font-size: 1.2rem;
+}
+
 
 .section--goals .section__heading {
     max-width: 100%;


### PR DESCRIPTION
## Summary
- enlarge the highlights section intro paragraph to improve readability on the news page
- allow the highlights section heading group to span the full width so the intro sentence doesn’t wrap mid-line

## Testing
- not run (not run)


------
https://chatgpt.com/codex/tasks/task_e_68e67137f34c832bb0509cb69e3b6da6