### PR TITLE
Remove objectives card background and blend icons

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -659,8 +659,8 @@ a:focus {
 }
 
 .objectives-card {
-    background: #ffffff;
-    border: 1px solid var(--surface-border);
+    background: transparent;
+    border: none;
     border-radius: 0;
     padding: clamp(2.25rem, 4vw, 3rem);
     box-shadow: none;
@@ -703,7 +703,8 @@ a:focus {
     width: 100%;
     height: 100%;
     object-fit: contain;
-    filter: none;
+    mix-blend-mode: multiply;
+    filter: brightness(1.05) contrast(1.1);
 }
 
 .objective-card__content {


### PR DESCRIPTION
## Summary
- remove the white surface from the goals card container
- blend the goal icons with the section background to hide their white backdrop

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e673c5c638832b8f9d93c4c28b61f0