### PR TITLE
Refine contact hero layout

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -874,24 +874,26 @@ a:focus {
 .contact-hero__header {
     display: grid;
     gap: 0.75rem;
-    text-align: center;
-    max-width: 100%;
+    text-align: left;
+    max-width: min(100%, 56rem);
     margin-inline: auto;
     color: var(--color-heading);
+    padding: 0;
 }
 
 .contact-hero__header h1 {
     margin: 0;
-    font-size: calc(clamp(1.83rem, 4.2vw, 2.73rem) - 2pt);
+    font-size: clamp(2.5rem, 5.6vw, 3.6rem);
     color: var(--color-heading);
-    letter-spacing: -0.01em;
+    letter-spacing: -0.015em;
+    text-transform: none;
 }
 
 .contact-hero__header p {
     margin: 0;
-    color: var(--color-muted);
+    color: rgba(37, 38, 58, 0.72);
     line-height: 1.6;
-    font-size: clamp(1.1rem, 2.2vw, 1.25rem);
+    font-size: clamp(1.12rem, 2.2vw, 1.28rem);
 }
 
 .contact-hero__content {
@@ -949,6 +951,7 @@ a:focus {
     .contact-hero__header {
         text-align: left;
         margin-inline: 0;
+        padding: 0;
     }
 
     .contact-hero__content {
@@ -964,7 +967,7 @@ a:focus {
     }
 
     .contact-hero__header {
-        max-width: 32rem;
+        max-width: min(100%, 48rem);
         align-self: end;
     }
 
@@ -988,7 +991,8 @@ a:focus {
         grid-row: 1 / span 2;
         justify-self: stretch;
         align-self: stretch;
-        max-width: 440px;
+        max-width: 560px;
+        margin-top: clamp(2rem, 4vw, 3.5rem);
     }
 
     .contact-hero__form-inner {
@@ -1006,8 +1010,8 @@ a:focus {
     gap: clamp(1.5rem, 3vw, 2.25rem);
     padding-block: clamp(0.25rem, 1.5vw, 1.5rem);
     padding-inline: clamp(0rem, 1.5vw, 0.75rem);
-    justify-items: center;
-    text-align: center;
+    justify-items: start;
+    text-align: left;
 }
 
 .contact-details {
@@ -1016,13 +1020,16 @@ a:focus {
     padding: 0;
     display: grid;
     gap: clamp(1rem, 2.5vw, 1.6rem);
+    justify-items: start;
 }
 
 
 .contact-detail {
     display: grid;
-    gap: 0.85rem;
-    justify-items: center;
+    grid-template-columns: auto 1fr;
+    align-items: center;
+    gap: 0.75rem 1rem;
+    justify-items: start;
 }
 
 .contact-detail__icon {
@@ -1033,6 +1040,7 @@ a:focus {
     height: 3.5rem;
     border-radius: 50%;
     color: var(--color-primary);
+    align-self: start;
 }
 
 .contact-detail__icon svg {
@@ -1045,27 +1053,28 @@ a:focus {
 .contact-detail__text {
     display: grid;
     gap: 0.2rem;
-    text-align: center;
+    text-align: left;
 }
 
 .contact-detail__label {
     font-weight: 600;
-    letter-spacing: 0.04em;
+    letter-spacing: 0.08em;
     text-transform: uppercase;
-    font-size: 0.8rem;
-    color: rgba(37, 38, 58, 0.72);
+    font-size: 0.78rem;
+    color: rgba(37, 38, 58, 0.58);
 }
 
 .contact-detail__text a,
 .contact-detail__text address {
-    font-size: 1.12rem;
+    font-size: 1.1rem;
     font-style: normal;
     color: var(--color-heading);
     line-height: 1.5;
+    font-weight: 600;
 }
 
 .contact-detail__text a {
-    font-weight: 400;
+    font-weight: 600;
 }
 
 .contact-detail__text a:hover,
@@ -1076,16 +1085,17 @@ a:focus {
 .contact-social {
     display: grid;
     gap: 0.75rem;
+    justify-items: start;
 }
 
 .contact-social__label {
     margin: 0;
     font-weight: 600;
-    color: rgba(37, 38, 58, 0.72);
+    color: rgba(37, 38, 58, 0.62);
     text-transform: uppercase;
     letter-spacing: 0.05em;
     font-size: 0.82rem;
-    text-align: center;
+    text-align: left;
 }
 
 
@@ -1093,7 +1103,7 @@ a:focus {
     display: flex;
     flex-wrap: wrap;
     gap: 0.75rem;
-    justify-content: center;
+    justify-content: flex-start;
 }
 
 .contact-social__icon {
@@ -1674,7 +1684,8 @@ a:focus {
     box-shadow: 0 20px 42px rgba(58, 104, 153, 0.25);
     overflow: hidden;
     color: #f9f7ff;
-    max-width: min(100%, 420px);
+    max-width: min(100%, 540px);
+    margin-top: clamp(1.5rem, 4vw, 3rem);
 }
 
 .contact-hero__content .contact-hero__form {

--- a/contact.html
+++ b/contact.html
@@ -33,7 +33,7 @@
         <section class="section contact-hero" aria-labelledby="contact-intro-title">
             <div class="contact-hero__container">
                 <div class="contact-hero__header">
-                    <h1 id="contact-intro-title">Get in touch</h1>
+                    <h1 id="contact-intro-title">get in touch</h1>
                     <p>For inquiries regarding collaborations, partnerships, or general matters, reach out to us or arrange a meeting at our main office.</p>
                 </div>
                 <div class="contact-hero__content">


### PR DESCRIPTION
## Summary
- Remove the decorative card treatment from the contact hero heading and keep the title in lowercase styling
- Realign the contact details icons, labels, and copy so the contact information reads in a consistent left-aligned column

## Testing
- No automated tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68e671b69878832babd9a43dd4e86d5e