### PR TITLE
Align contact hero heading with form

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -988,7 +988,7 @@ a:focus {
 
     .contact-hero__header {
         max-width: min(100%, 48rem);
-        align-self: end;
+        align-self: start;
     }
 
     .contact-hero__content {
@@ -1012,7 +1012,7 @@ a:focus {
         justify-self: stretch;
         align-self: stretch;
         max-width: 560px;
-        margin-top: clamp(2rem, 4vw, 3.5rem);
+        margin-top: 0;
     }
 
     .contact-hero__form-inner {


### PR DESCRIPTION
## Summary
- align the Get in touch heading with the top of the contact form on large screens
- remove excess spacing so the contact details stack higher next to the form

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e676f13358832bb538b2e932734f92