### PR TITLE
Enhance emphasis for goals and collaboration messaging

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -649,6 +649,11 @@ a:focus {
     font-size: 1.05rem;
 }
 
+.section__heading .section__lead {
+    font-size: clamp(1.15rem, 2.4vw, 1.4rem);
+    line-height: 1.6;
+}
+
 .highlights .section__heading {
     max-width: 100%;
 }

--- a/index.html
+++ b/index.html
@@ -72,7 +72,7 @@
         <section class="section section--muted section--goals" aria-labelledby="goals-title">
             <div class="section__heading">
                 <h2 id="goals-title">Our Goals</h2>
-                <p>Three priorities guide how we translate consciousness research into meaningful impact.</p>
+                <p class="section__lead">Three priorities guide how we translate consciousness research into meaningful impact.</p>
             </div>
             <div class="objectives-card" role="group" aria-labelledby="goals-title">
                 <div class="objectives-card__list" role="list">
@@ -110,7 +110,7 @@
         <section class="section section--surface section--cta" aria-labelledby="cta-title">
             <div class="section__heading">
                 <h2 id="cta-title">Ready to collaborate?</h2>
-                <p>Let’s explore meaningful partnerships that shape the future of conscious AI together.</p>
+                <p class="section__lead">Let’s explore meaningful partnerships that shape the future of conscious AI together.</p>
             </div>
             <a class="cta-button" href="contact.html">Contact us</a>
         </section>


### PR DESCRIPTION
## Summary
- add a reusable `section__lead` style to enlarge key section heading text
- apply the lead styling to the goals and collaboration paragraphs on the home page

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68e677e982fc832ba31259ca3b4e8c80