### PR TITLE
Restore about section margins

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -742,7 +742,7 @@ a:focus {
 
 .section--about {
     position: relative;
-    max-width: min(96vw, calc(var(--layout-max-width) + 140px));
+    max-width: var(--layout-fluid-width);
 }
 
 .about-layout {


### PR DESCRIPTION
## Summary
- restore the about section container width to use the standard layout fluid width so side margins match the rest of the site

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e677b5c7fc832b9dab9b3b69691619