### PR TITLE
Expand contact form width

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -980,13 +980,13 @@ a:focus {
     }
 
     .contact-hero__content {
-        grid-template-columns: minmax(0, 1.05fr) minmax(0, 0.85fr);
+        grid-template-columns: minmax(0, 0.95fr) minmax(0, 1.05fr);
     }
 }
 
 @media (min-width: 1100px) {
     .contact-hero__container {
-        grid-template-columns: minmax(0, 1.05fr) minmax(0, 0.9fr);
+        grid-template-columns: minmax(0, 0.95fr) minmax(0, 1.05fr);
         grid-auto-rows: min-content;
         align-items: stretch;
     }
@@ -1016,7 +1016,7 @@ a:focus {
         grid-row: 1 / span 2;
         justify-self: stretch;
         align-self: stretch;
-        max-width: 560px;
+        max-width: 680px;
         margin-top: 0;
     }
 
@@ -1709,7 +1709,7 @@ a:focus {
     box-shadow: 0 20px 42px rgba(58, 104, 153, 0.25);
     overflow: hidden;
     color: #f9f7ff;
-    max-width: min(100%, 540px);
+    max-width: min(100%, 660px);
     margin-top: clamp(1.5rem, 4vw, 3rem);
 }
 


### PR DESCRIPTION
## Summary
- widen the contact form container so it occupies more horizontal space on the contact page
- rebalance the large-screen grid layout so the form receives a larger share of the available width

## Testing
- Not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68e679d46f00832b99b12068b519b02a