### PR TITLE
Adjust contact form status spacing

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -1962,6 +1962,8 @@ a:focus {
 }
 
 .contact-page .form-status {
+    margin: 0.15rem 0 0;
+    min-height: 1.1rem;
     color: rgba(249, 247, 255, 0.82);
 }
 


### PR DESCRIPTION
## Summary
- reduce the space below the Send request button by tightening the form status margin while reserving room for feedback messages

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68e6843d547c832b9ab65953a41dd188