### PR TITLE
Rebuild team cards with version 3 layout

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -1541,60 +1541,6 @@ a:focus {
     color: #4b5669;
 }
 
-.team-card__bio {
-    margin: 0;
-    color: #6b7286;
-    font-size: 0.97rem;
-}
-
-.team-card__links {
-    list-style: none;
-    display: flex;
-    flex-wrap: wrap;
-    gap: 0.65rem;
-    padding: 0;
-    margin: 0;
-}
-
-.team-card__link {
-    position: relative;
-    display: grid;
-    place-items: center;
-    width: 2.5rem;
-    height: 2.5rem;
-    border-radius: 0;
-    border: 1px solid var(--card-border);
-    background: var(--card-fill);
-    transition: transform 0.2s ease, box-shadow 0.2s ease, border-color 0.2s ease;
-    overflow: hidden;
-}
-
-.team-card__link-icon {
-    width: 1.35rem;
-    height: 1.35rem;
-    object-fit: contain;
-}
-
-.team-card__link::before {
-    display: none;
-}
-
-.team-card__link[data-icon]::before {
-    display: inline-block;
-    content: attr(data-icon);
-    font-size: 0.85rem;
-    font-weight: 700;
-    text-transform: uppercase;
-    color: var(--color-primary);
-}
-
-.team-card__link:hover,
-.team-card__link:focus-visible {
-    transform: translateY(-2px);
-    border-color: var(--color-secondary);
-    box-shadow: 0 16px 32px rgba(64, 89, 142, 0.18);
-}
-
 .team-section .section__heading {
     max-width: none;
     margin: 0;
@@ -1624,36 +1570,30 @@ a:focus {
 .team-card {
     background: transparent;
     border-radius: 18px;
-    overflow: hidden;
-    display: flex;
-    flex-direction: column;
-    height: 100%;
+    display: grid;
+    justify-items: center;
+    align-content: start;
+    text-align: center;
+    gap: 0.55rem;
+    padding: 0.5rem 0.5rem 1.1rem;
 }
 
-.team-card__photo {
-    aspect-ratio: 1 / 1;
+.team-card__figure {
+    margin: 0;
     display: grid;
     place-items: center;
-    background: #e3e7f1;
-    border-radius: 16px;
-    overflow: hidden;
-}
-
-.team-card__photo img {
     width: 100%;
-    height: 100%;
-    object-fit: cover;
 }
 
-.team-card__body {
-    display: grid;
-    gap: 0.45rem;
-    padding: 1.15rem 0.5rem 0.25rem;
-    flex: 1;
-    text-align: center;
+.team-card__portrait {
+    width: min(78%, 11.5rem);
+    aspect-ratio: 1 / 1;
+    object-fit: contain;
+    display: block;
+    margin: 0 auto;
 }
 
-.team-card__body h3 {
+.team-card__name {
     margin: 0;
     color: #1f2d44;
     font-size: 1.05rem;
@@ -1665,6 +1605,40 @@ a:focus {
     font-weight: 600;
     color: #4f5971;
     font-size: 1.05rem;
+}
+
+.team-card__links {
+    list-style: none;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.6rem;
+    padding: 0;
+    margin: 0.35rem 0 0;
+    justify-content: center;
+}
+
+.team-card__links li {
+    display: inline-flex;
+}
+
+.team-card__link {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 2.25rem;
+    height: 2.25rem;
+    transition: transform 0.2s ease;
+}
+
+.team-card__link:hover,
+.team-card__link:focus-visible {
+    transform: translateY(-2px) scale(1.04);
+}
+
+.team-card__icon {
+    width: 1.4rem;
+    height: 1.4rem;
+    object-fit: contain;
 }
 
 @media (max-width: 1280px) {

--- a/team.html
+++ b/team.html
@@ -79,58 +79,208 @@
             </div>
             <div class="team-grid">
                 <article class="team-card">
-                    <div class="team-card__photo">
-                        <img src="assets/images/team/people_photos/pietro_avanzini.jpg" alt="Portrait of Pietro Avanzini">
-                    </div>
-                    <div class="team-card__body">
-                        <h3>Pietro Avanzini</h3>
-                        <p class="team-card__role">Principal Investigator</p>
-                    </div>
+                    <figure class="team-card__figure">
+                        <img class="team-card__portrait" src="assets/images/team/people_photos/pietro_avanzini.jpg" alt="Portrait of Pietro Avanzini">
+                    </figure>
+                    <h3 class="team-card__name">Pietro Avanzini</h3>
+                    <p class="team-card__role">Principal Investigator</p>
+                    <ul class="team-card__links" aria-label="Pietro Avanzini contact options">
+                        <li>
+                            <a class="team-card__link" href="#" aria-label="Email Pietro Avanzini">
+                                <img class="team-card__icon" src="assets/images/team/icons/mail.jpg" alt="Mail icon">
+                            </a>
+                        </li>
+                        <li>
+                            <a class="team-card__link" href="#" aria-label="Visit Pietro Avanzini on LinkedIn">
+                                <img class="team-card__icon" src="assets/images/team/icons/linkedin.jpg" alt="LinkedIn icon">
+                            </a>
+                        </li>
+                        <li>
+                            <a class="team-card__link" href="#" aria-label="Visit Pietro Avanzini's Google Scholar profile">
+                                <img class="team-card__icon" src="assets/images/team/icons/googlescholar.jpg" alt="Google Scholar icon">
+                            </a>
+                        </li>
+                        <li>
+                            <a class="team-card__link" href="#" aria-label="Visit Pietro Avanzini's website">
+                                <img class="team-card__icon" src="assets/images/team/icons/website.jpg" alt="Website icon">
+                            </a>
+                        </li>
+                        <li>
+                            <a class="team-card__link" href="#" aria-label="Visit Pietro Avanzini on GitHub">
+                                <img class="team-card__icon" src="assets/images/team/icons/github.svg" alt="GitHub icon">
+                            </a>
+                        </li>
+                    </ul>
                 </article>
                 <article class="team-card">
-                    <div class="team-card__photo">
-                        <img src="assets/images/team/people_photos/lorenzo_pini.png" alt="Portrait of Lorenzo Pini">
-                    </div>
-                    <div class="team-card__body">
-                        <h3>Lorenzo Pini</h3>
-                        <p class="team-card__role">Research Scientist</p>
-                    </div>
+                    <figure class="team-card__figure">
+                        <img class="team-card__portrait" src="assets/images/team/people_photos/lorenzo_pini.png" alt="Portrait of Lorenzo Pini">
+                    </figure>
+                    <h3 class="team-card__name">Lorenzo Pini</h3>
+                    <p class="team-card__role">Research Scientist</p>
+                    <ul class="team-card__links" aria-label="Lorenzo Pini contact options">
+                        <li>
+                            <a class="team-card__link" href="#" aria-label="Email Lorenzo Pini">
+                                <img class="team-card__icon" src="assets/images/team/icons/mail.jpg" alt="Mail icon">
+                            </a>
+                        </li>
+                        <li>
+                            <a class="team-card__link" href="#" aria-label="Visit Lorenzo Pini on LinkedIn">
+                                <img class="team-card__icon" src="assets/images/team/icons/linkedin.jpg" alt="LinkedIn icon">
+                            </a>
+                        </li>
+                        <li>
+                            <a class="team-card__link" href="#" aria-label="Visit Lorenzo Pini's Google Scholar profile">
+                                <img class="team-card__icon" src="assets/images/team/icons/googlescholar.jpg" alt="Google Scholar icon">
+                            </a>
+                        </li>
+                        <li>
+                            <a class="team-card__link" href="#" aria-label="Visit Lorenzo Pini's website">
+                                <img class="team-card__icon" src="assets/images/team/icons/website.jpg" alt="Website icon">
+                            </a>
+                        </li>
+                        <li>
+                            <a class="team-card__link" href="#" aria-label="Visit Lorenzo Pini on GitHub">
+                                <img class="team-card__icon" src="assets/images/team/icons/github.svg" alt="GitHub icon">
+                            </a>
+                        </li>
+                    </ul>
                 </article>
                 <article class="team-card">
-                    <div class="team-card__photo">
-                        <img src="assets/images/team/people_photos/profile-placeholder.svg" alt="Portrait of Andrea Pigorini">
-                    </div>
-                    <div class="team-card__body">
-                        <h3>Andrea Pigorini</h3>
-                        <p class="team-card__role">Research Scientist</p>
-                    </div>
+                    <figure class="team-card__figure">
+                        <img class="team-card__portrait" src="assets/images/team/people_photos/profile-placeholder.svg" alt="Portrait of Andrea Pigorini">
+                    </figure>
+                    <h3 class="team-card__name">Andrea Pigorini</h3>
+                    <p class="team-card__role">Research Scientist</p>
+                    <ul class="team-card__links" aria-label="Andrea Pigorini contact options">
+                        <li>
+                            <a class="team-card__link" href="#" aria-label="Email Andrea Pigorini">
+                                <img class="team-card__icon" src="assets/images/team/icons/mail.jpg" alt="Mail icon">
+                            </a>
+                        </li>
+                        <li>
+                            <a class="team-card__link" href="#" aria-label="Visit Andrea Pigorini on LinkedIn">
+                                <img class="team-card__icon" src="assets/images/team/icons/linkedin.jpg" alt="LinkedIn icon">
+                            </a>
+                        </li>
+                        <li>
+                            <a class="team-card__link" href="#" aria-label="Visit Andrea Pigorini's Google Scholar profile">
+                                <img class="team-card__icon" src="assets/images/team/icons/googlescholar.jpg" alt="Google Scholar icon">
+                            </a>
+                        </li>
+                        <li>
+                            <a class="team-card__link" href="#" aria-label="Visit Andrea Pigorini's website">
+                                <img class="team-card__icon" src="assets/images/team/icons/website.jpg" alt="Website icon">
+                            </a>
+                        </li>
+                        <li>
+                            <a class="team-card__link" href="#" aria-label="Visit Andrea Pigorini on GitHub">
+                                <img class="team-card__icon" src="assets/images/team/icons/github.svg" alt="GitHub icon">
+                            </a>
+                        </li>
+                    </ul>
                 </article>
                 <article class="team-card">
-                    <div class="team-card__photo">
-                        <img src="assets/images/team/people_photos/profile-placeholder.svg" alt="Portrait of Maurizio Corbetta">
-                    </div>
-                    <div class="team-card__body">
-                        <h3>Maurizio Corbetta</h3>
-                        <p class="team-card__role">Principal Investigator</p>
-                    </div>
+                    <figure class="team-card__figure">
+                        <img class="team-card__portrait" src="assets/images/team/people_photos/profile-placeholder.svg" alt="Portrait of Maurizio Corbetta">
+                    </figure>
+                    <h3 class="team-card__name">Maurizio Corbetta</h3>
+                    <p class="team-card__role">Principal Investigator</p>
+                    <ul class="team-card__links" aria-label="Maurizio Corbetta contact options">
+                        <li>
+                            <a class="team-card__link" href="#" aria-label="Email Maurizio Corbetta">
+                                <img class="team-card__icon" src="assets/images/team/icons/mail.jpg" alt="Mail icon">
+                            </a>
+                        </li>
+                        <li>
+                            <a class="team-card__link" href="#" aria-label="Visit Maurizio Corbetta on LinkedIn">
+                                <img class="team-card__icon" src="assets/images/team/icons/linkedin.jpg" alt="LinkedIn icon">
+                            </a>
+                        </li>
+                        <li>
+                            <a class="team-card__link" href="#" aria-label="Visit Maurizio Corbetta's Google Scholar profile">
+                                <img class="team-card__icon" src="assets/images/team/icons/googlescholar.jpg" alt="Google Scholar icon">
+                            </a>
+                        </li>
+                        <li>
+                            <a class="team-card__link" href="#" aria-label="Visit Maurizio Corbetta's website">
+                                <img class="team-card__icon" src="assets/images/team/icons/website.jpg" alt="Website icon">
+                            </a>
+                        </li>
+                        <li>
+                            <a class="team-card__link" href="#" aria-label="Visit Maurizio Corbetta on GitHub">
+                                <img class="team-card__icon" src="assets/images/team/icons/github.svg" alt="GitHub icon">
+                            </a>
+                        </li>
+                    </ul>
                 </article>
                 <article class="team-card">
-                    <div class="team-card__photo">
-                        <img src="assets/images/team/people_photos/profile-placeholder.svg" alt="Portrait of Emma Maria Sole Tosato">
-                    </div>
-                    <div class="team-card__body">
-                        <h3>Emma Maria Sole Tosato</h3>
-                        <p class="team-card__role">PhD Student</p>
-                    </div>
+                    <figure class="team-card__figure">
+                        <img class="team-card__portrait" src="assets/images/team/people_photos/profile-placeholder.svg" alt="Portrait of Emma Maria Sole Tosato">
+                    </figure>
+                    <h3 class="team-card__name">Emma Maria Sole Tosato</h3>
+                    <p class="team-card__role">PhD Student</p>
+                    <ul class="team-card__links" aria-label="Emma Maria Sole Tosato contact options">
+                        <li>
+                            <a class="team-card__link" href="#" aria-label="Email Emma Maria Sole Tosato">
+                                <img class="team-card__icon" src="assets/images/team/icons/mail.jpg" alt="Mail icon">
+                            </a>
+                        </li>
+                        <li>
+                            <a class="team-card__link" href="#" aria-label="Visit Emma Maria Sole Tosato on LinkedIn">
+                                <img class="team-card__icon" src="assets/images/team/icons/linkedin.jpg" alt="LinkedIn icon">
+                            </a>
+                        </li>
+                        <li>
+                            <a class="team-card__link" href="#" aria-label="Visit Emma Maria Sole Tosato's Google Scholar profile">
+                                <img class="team-card__icon" src="assets/images/team/icons/googlescholar.jpg" alt="Google Scholar icon">
+                            </a>
+                        </li>
+                        <li>
+                            <a class="team-card__link" href="#" aria-label="Visit Emma Maria Sole Tosato's website">
+                                <img class="team-card__icon" src="assets/images/team/icons/website.jpg" alt="Website icon">
+                            </a>
+                        </li>
+                        <li>
+                            <a class="team-card__link" href="#" aria-label="Visit Emma Maria Sole Tosato on GitHub">
+                                <img class="team-card__icon" src="assets/images/team/icons/github.svg" alt="GitHub icon">
+                            </a>
+                        </li>
+                    </ul>
                 </article>
                 <article class="team-card">
-                    <div class="team-card__photo">
-                        <img src="assets/images/team/people_photos/profile-placeholder.svg" alt="Portrait of Bita Darabi">
-                    </div>
-                    <div class="team-card__body">
-                        <h3>Bita Darabi</h3>
-                        <p class="team-card__role">PhD Student</p>
-                    </div>
+                    <figure class="team-card__figure">
+                        <img class="team-card__portrait" src="assets/images/team/people_photos/profile-placeholder.svg" alt="Portrait of Bita Darabi">
+                    </figure>
+                    <h3 class="team-card__name">Bita Darabi</h3>
+                    <p class="team-card__role">PhD Student</p>
+                    <ul class="team-card__links" aria-label="Bita Darabi contact options">
+                        <li>
+                            <a class="team-card__link" href="#" aria-label="Email Bita Darabi">
+                                <img class="team-card__icon" src="assets/images/team/icons/mail.jpg" alt="Mail icon">
+                            </a>
+                        </li>
+                        <li>
+                            <a class="team-card__link" href="#" aria-label="Visit Bita Darabi on LinkedIn">
+                                <img class="team-card__icon" src="assets/images/team/icons/linkedin.jpg" alt="LinkedIn icon">
+                            </a>
+                        </li>
+                        <li>
+                            <a class="team-card__link" href="#" aria-label="Visit Bita Darabi's Google Scholar profile">
+                                <img class="team-card__icon" src="assets/images/team/icons/googlescholar.jpg" alt="Google Scholar icon">
+                            </a>
+                        </li>
+                        <li>
+                            <a class="team-card__link" href="#" aria-label="Visit Bita Darabi's website">
+                                <img class="team-card__icon" src="assets/images/team/icons/website.jpg" alt="Website icon">
+                            </a>
+                        </li>
+                        <li>
+                            <a class="team-card__link" href="#" aria-label="Visit Bita Darabi on GitHub">
+                                <img class="team-card__icon" src="assets/images/team/icons/github.svg" alt="GitHub icon">
+                            </a>
+                        </li>
+                    </ul>
                 </article>
             </div>
         </section>


### PR DESCRIPTION
## Summary
- rebuild the team card markup around the updated portraits and shared icon set
- refresh the team card styling so transparent images sit centered and icons keep uniform sizing while preserving the four-column grid

## Testing
- Manual inspection of team.html

------
https://chatgpt.com/codex/tasks/task_e_68e67f7632f4832baa907f121ba034d8