### PR TITLE
Adjust contact page spacing

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -155,7 +155,34 @@ body {
 }
 
 body.contact-page {
-    font-size: clamp(16px, 1.4vw, 17px);
+    font-size: clamp(15px, 1.2vw, 16px);
+}
+
+.contact-page .navbar {
+    padding: 0.5rem 1.25rem;
+    gap: 1.1rem;
+}
+
+.contact-page .navbar__brand {
+    gap: 0.9rem;
+    padding: 0.35rem 0.55rem 0.35rem 0.35rem;
+}
+
+.contact-page .navbar__crest {
+    width: 3rem;
+    height: 3rem;
+}
+
+.contact-page .navbar__title {
+    font-size: clamp(1.45rem, 1.6vw + 0.95rem, 1.95rem);
+}
+
+.contact-page .navbar__menu {
+    gap: 1.25rem;
+}
+
+.contact-page .navbar__link {
+    font-size: 0.88rem;
 }
 
 img {
@@ -852,20 +879,20 @@ a:focus {
 
 
 .contact-hero {
-    padding-block: clamp(2.5rem, 5vw, 4.5rem);
+    padding-block: clamp(2rem, 4.5vw, 4rem);
 }
 
 .contact-hero__container {
     max-width: var(--layout-fluid-width);
     margin: 0 auto;
-    padding-inline: clamp(1rem, 4vw, 2.5rem);
+    padding-inline: clamp(1rem, 3.5vw, 2.2rem);
     display: grid;
-    gap: clamp(1.75rem, 4vw, 2.75rem);
+    gap: clamp(1.5rem, 3.5vw, 2.5rem);
 }
 
 .contact-hero__header {
     display: grid;
-    gap: 0.75rem;
+    gap: 0.6rem;
     text-align: left;
     max-width: min(100%, 56rem);
     margin-inline: auto;
@@ -875,7 +902,7 @@ a:focus {
 
 .contact-hero__header h1 {
     margin: 0;
-    font-size: clamp(2.5rem, 5.6vw, 3.6rem);
+    font-size: clamp(2.2rem, 5vw, 3.3rem);
     color: var(--color-heading);
     letter-spacing: -0.015em;
     text-transform: none;
@@ -885,7 +912,7 @@ a:focus {
     margin: 0;
     color: rgba(37, 38, 58, 0.72);
     line-height: 1.6;
-    font-size: clamp(1.12rem, 2.2vw, 1.28rem);
+    font-size: clamp(1.05rem, 2vw, 1.22rem);
 }
 
 .contact-hero__content {


### PR DESCRIPTION
## Summary
- reduce the contact page navigation padding and typography to conserve vertical space
- tighten the contact hero header spacing so the detail/form content stays prominent

## Testing
- not run (static content change)


------
https://chatgpt.com/codex/tasks/task_e_68e685601a20832bb2198f78f3ae9b43