### PR TITLE
Align team hero button with CTA styling

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -474,22 +474,12 @@ a:focus {
 
 .hero-institutions .hero-institutions__cta {
     margin-top: 0.75rem;
-    background: #324d7d;
-    color: #f8f9ff;
-    box-shadow: none;
-    padding: 0.65rem 1.6rem;
-    border-radius: 6px;
-    border: 1px solid rgba(50, 77, 125, 0.18);
-    transform: none;
-    transition: background 0.2s ease, color 0.2s ease, border-color 0.2s ease;
+    text-transform: none;
 }
 
 .hero-institutions .hero-institutions__cta:hover,
 .hero-institutions .hero-institutions__cta:focus {
-    background: #293f65;
-    border-color: rgba(50, 77, 125, 0.28);
-    box-shadow: none;
-    transform: none;
+    text-transform: none;
 }
 
 .hero-institutions__logos {

--- a/team.html
+++ b/team.html
@@ -40,7 +40,7 @@
                 <div class="section__content hero-institutions__content">
                     <h1 id="institutions-title">Partner Institutions and Universities</h1>
                     <p>We design ethical, human-centered neurotechnologies side-by-side with leading universities and research institutes across Italy.</p>
-                    <a class="button hero-institutions__cta" href="#team-section">Meet the team</a>
+                    <a class="cta-button hero-institutions__cta" href="#team-section">Meet the team</a>
                 </div>
                 <div class="hero-institutions__logos" aria-label="Institution partners">
                     <div class="institution-list">


### PR DESCRIPTION
## Summary
- reuse the primary call-to-action button styling for the team hero link
- override the hero button casing so the existing capitalization is preserved

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e687eec9f8832babb48f63008fc573