### PR TITLE
Reduce contact form footer spacing

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -1719,7 +1719,7 @@ a:focus {
     display: grid;
     gap: clamp(1.4rem, 3vw, 2.1rem);
     padding: clamp(1.6rem, 4vw, 2.4rem);
-    padding-bottom: clamp(1rem, 3vw, 1.6rem);
+    padding-bottom: clamp(0.6rem, 2.5vw, 1.1rem);
     height: 100%;
 }
 


### PR DESCRIPTION
## Summary
- reduce the bottom padding of the contact form panel to lessen the space beneath the submit button

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e68890dbd0832b970996cf34f0653f