### PR TITLE
Add GitHub Pages deployment workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,49 @@
+name: Deploy static site to GitHub Pages
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Configure Pages
+        uses: actions/configure-pages@v4
+
+      - name: Prepare static site artifact
+        run: |
+          mkdir -p public
+          cp -r assets public/
+          cp ./*.html public/
+          touch public/.nojekyll
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: ./public
+
+  deploy:
+    needs: build
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/README.md
+++ b/README.md
@@ -57,3 +57,14 @@ python3 -m http.server
 ```
 
 Visitando `http://localhost:8000` potrai navigare tutte le pagine e verificare il comportamento della barra di navigazione responsive e della pagina eventi dinamica.
+
+## Pubblicazione su GitHub Pages
+
+Il repository include un workflow GitHub Actions (`.github/workflows/deploy.yml`) che pubblica automaticamente il sito come GitHub Page.
+
+1. Vai su **Settings → Pages** nel repository GitHub.
+2. Seleziona **GitHub Actions** come sorgente di pubblicazione.
+3. Verifica che il branch predefinito sia `main` e salva.
+4. Ogni push su `main` (oppure l'avvio manuale del workflow) genererà un artifact con tutti i file HTML e la cartella `assets`, quindi aggiornerà il branch `gh-pages` e l'URL pubblico del sito.
+
+Quando la prima esecuzione del workflow sarà completata, GitHub mostrerà l'indirizzo definitivo della pagina nella scheda **Deployments**.


### PR DESCRIPTION
## Summary
- add a GitHub Actions workflow that prepares the static site and deploys it to GitHub Pages
- document the publication steps for enabling the workflow in the project README

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e68aaa9c0c832b8a01f51100c7296b