### PR TITLE
Fix hero spacing on team page

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -428,7 +428,7 @@ a:focus {
     background: linear-gradient(180deg, #f8f9ff 0%, #f1f0fb 55%, #f5ede7 100%);
     color: var(--color-text);
     padding: clamp(4.5rem, 15vh, 7rem) 0 clamp(4rem, 14vh, 6.5rem);
-    margin-top: clamp(1.5rem, 4vw, 2.75rem);
+    margin-top: 0;
 }
 
 .hero-institutions::before {


### PR DESCRIPTION
## Summary
- remove the top margin from the team hero section so it sits flush against the header

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e77d1a0270832bb32b3793e4ab94d7