### PR TITLE
Adjust spacing above team heading

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -1626,6 +1626,7 @@ a:focus {
     max-width: none;
     margin: 0;
     width: 100%;
+    padding-top: clamp(2.5rem, 8vw, 4.5rem);
     padding-inline: clamp(1.5rem, 8vw, 6rem);
     position: relative;
 }


### PR DESCRIPTION
## Summary
- add top padding to the calm team section layout so the heading sits below the navigation bar

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e787c0eea4832bb645d12d375f532c