### PR TITLE
Restyle CTA button to match square design

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -967,20 +967,22 @@ a:focus {
     display: inline-flex;
     align-items: center;
     justify-content: center;
-    padding: 0.75rem 1.75rem;
-    border: 1px solid rgba(255, 255, 255, 0.45);
-    border-radius: 999px;
-    background: var(--gradient-header);
-    color: var(--color-heading);
+    padding: 0.85rem 2.75rem;
+    border: none;
+    border-radius: 0;
+    background: #13254b;
+    color: #ffffff;
     font-weight: 600;
-    letter-spacing: 0.02em;
-    transition: background-color 0.2s ease, color 0.2s ease;
+    letter-spacing: 0.01em;
+    box-shadow: 0 14px 28px rgba(19, 37, 75, 0.28);
+    transition: transform 0.2s ease, box-shadow 0.2s ease, background-color 0.2s ease;
 }
 
 .cta-button:hover,
 .cta-button:focus {
-    filter: brightness(0.95);
-    box-shadow: 0 16px 34px rgba(58, 104, 153, 0.22);
+    background-color: #0f1e3d;
+    transform: translateY(-2px);
+    box-shadow: 0 18px 36px rgba(19, 37, 75, 0.32);
 }
 
 


### PR DESCRIPTION
## Summary
- restyled the homepage call-to-action button with a square navy design and updated hover feedback

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68e787683ef4832b822eeb4d43812cf6