### PR TITLE
Adjust contact hero spacing

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -985,7 +985,8 @@ a:focus {
 
 
 .contact-hero {
-    padding-block: clamp(2rem, 4.5vw, 4rem);
+    padding-block-start: clamp(2rem, 4.5vw, 4rem);
+    padding-block-end: clamp(3.5rem, 6vw, 6rem);
 }
 
 .contact-hero__container {


### PR DESCRIPTION
## Summary
- increase the contact hero section's bottom padding to give the form and header more clearance from the footer

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68e7888455c4832b87324734b884c991