### PR TITLE
Align partner logos with heading

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -519,12 +519,13 @@ a:focus {
     margin: 0 auto;
     padding-inline: clamp(1.5rem, 6vw, 4rem);
     box-sizing: border-box;
+    justify-content: center;
 }
 
 .hero-institutions__content {
     max-width: min(520px, 100%);
     display: grid;
-    gap: 1.25rem;
+    gap: 1.75rem;
     justify-items: start;
 }
 
@@ -534,6 +535,7 @@ a:focus {
     letter-spacing: -0.01em;
     margin: 0;
     white-space: normal;
+    line-height: 1.35;
 }
 
 .hero-institutions__content p {
@@ -544,7 +546,7 @@ a:focus {
 }
 
 .hero-institutions .hero-institutions__cta {
-    margin-top: 0.75rem;
+    margin-top: 1.5rem;
     text-transform: none;
     background: #1b2c4d;
     color: #f4f7ff;
@@ -572,6 +574,7 @@ a:focus {
     grid-template-columns: repeat(2, minmax(180px, 1fr));
     gap: clamp(1.85rem, 4.5vw, 3rem);
     width: min(600px, 100%);
+    margin-inline: auto;
 }
 
 .institution-list__item {
@@ -646,8 +649,26 @@ a:focus {
 
 @media (min-width: 900px) {
     .hero-institutions__layout {
-        grid-template-columns: minmax(320px, 1fr) minmax(380px, 1fr);
+        grid-template-columns: minmax(320px, 420px) minmax(340px, 480px);
         align-items: start;
+        column-gap: clamp(3.75rem, 8vw, 5.5rem);
+    }
+
+    .hero-institutions__content {
+        justify-items: end;
+        text-align: right;
+        padding-inline-end: clamp(1.25rem, 4vw, 2.75rem);
+        margin-top: clamp(-1rem, -2.5vw, -0.5rem);
+    }
+
+    .hero-institutions .hero-institutions__cta {
+        justify-self: end;
+        margin-top: clamp(2.25rem, 4vw, 3rem);
+    }
+
+    .hero-institutions__logos {
+        align-self: start;
+        margin-top: clamp(-2.5rem, -5vw, -1.75rem);
     }
 }
 


### PR DESCRIPTION
## Summary
- raise the partner logo grid further so the first row lines up with the hero heading on desktop
- increase the hero call-to-action's top margin to create more space below the heading

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e78a711e00832bbc127d58109fcf98