### PR TITLE
Adjust event card typography weights

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -1371,6 +1371,7 @@ a:focus {
     font-size: 1.15rem;
     line-height: 1.35;
     color: var(--color-primary);
+    font-weight: 600;
 }
 
 .highlight-card__title a {
@@ -1394,6 +1395,7 @@ a:focus {
     color: var(--color-text);
     line-height: 1.5;
     font-size: 0.95rem;
+    font-weight: 400;
 }
 
 .news-archive__accordion {
@@ -1497,6 +1499,7 @@ a:focus {
     margin: 0;
     font-size: 1.15rem;
     color: var(--color-heading);
+    font-weight: 600;
 }
 
 .news-card__title a {
@@ -1511,8 +1514,12 @@ a:focus {
 .news-card__date {
     margin: 0.3rem 0 0;
     color: var(--color-muted);
-    font-weight: 600;
+    font-weight: 500;
     font-size: 1rem;
+}
+
+.news-card__date strong {
+    font-weight: inherit;
 }
 
 .news-card__date--upcoming {
@@ -1523,6 +1530,7 @@ a:focus {
     margin: 0;
     color: var(--color-text);
     font-size: 0.9rem;
+    font-weight: 400;
 }
 
 @media (max-width: 720px) {


### PR DESCRIPTION
## Summary
- align event card typography with specified font weights for titles, dates, and descriptions
- normalize strong-tag styling so dates remain at the intended medium weight

## Testing
- no tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68e7a5cf1a50832bbff1d0b96bb8a56e