### PR TITLE
Refine contact details layout

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -996,7 +996,17 @@ a:focus {
     margin: 0 auto;
     padding-inline: clamp(1rem, 3.5vw, 2.2rem);
     display: grid;
-    gap: clamp(1.5rem, 3.5vw, 2.5rem);
+    gap: clamp(1.75rem, 4vw, 2.75rem);
+    align-items: stretch;
+}
+
+.contact-hero__details {
+    display: grid;
+    gap: clamp(1.5rem, 3vw, 2.3rem);
+    align-content: start;
+    width: 100%;
+    max-width: 680px;
+    margin: 0 auto;
 }
 
 .contact-hero__header {
@@ -1024,10 +1034,24 @@ a:focus {
     font-size: clamp(1.05rem, 2vw, 1.22rem);
 }
 
-.contact-hero__content {
+.contact-hero__info {
+    position: relative;
+    padding: clamp(0.5rem, 2vw, 1rem) 0;
+}
+
+.contact-hero__info::after {
+    display: none;
+}
+
+.contact-hero__info-inner {
     display: grid;
-    gap: clamp(1.75rem, 4vw, 2.5rem);
-    align-items: start;
+    gap: clamp(1.25rem, 3vw, 2rem);
+    padding: 0;
+    justify-items: start;
+    text-align: left;
+    position: relative;
+    z-index: 1;
+    width: 100%;
 }
 
 @media (min-width: 720px) {
@@ -1071,9 +1095,21 @@ a:focus {
     }
 }
 
+
+.contact-hero__info {
+    color: var(--color-heading);
+}
+
 @media (min-width: 960px) {
     .contact-hero__container {
-        gap: clamp(2rem, 4vw, 3rem);
+        grid-template-columns: minmax(0, 1.05fr) minmax(0, 0.95fr);
+        gap: clamp(2.4rem, 4.8vw, 3.6rem);
+    }
+
+    .contact-hero__details {
+        padding-right: clamp(0.5rem, 2vw, 1.4rem);
+        margin: 0;
+        max-width: none;
     }
 
     .contact-hero__header {
@@ -1081,21 +1117,12 @@ a:focus {
         margin-inline: 0;
         padding: 0;
     }
-
-    .contact-hero__content {
-        grid-template-columns: minmax(0, 0.95fr) minmax(0, 1.05fr);
-    }
-
-    .contact-hero__info {
-        margin-top: clamp(-3rem, -4vw, -1.25rem);
-    }
 }
 
 @media (min-width: 1100px) {
     .contact-hero__container {
-        grid-template-columns: minmax(0, 0.95fr) minmax(0, 1.05fr);
-        grid-auto-rows: min-content;
-        align-items: stretch;
+        grid-template-columns: minmax(0, 1.05fr) minmax(0, 0.95fr);
+        align-items: center;
     }
 
     .contact-hero__header {
@@ -1103,47 +1130,17 @@ a:focus {
         align-self: start;
     }
 
-    .contact-hero__content {
-        display: contents;
-    }
-
-    .contact-hero__info {
-        grid-column: 1 / 2;
-        grid-row: 2;
-        align-self: start;
+    .contact-hero__details {
+        gap: clamp(1.75rem, 3vw, 2.4rem);
     }
 
     .contact-hero__info-inner {
         max-width: 32rem;
-        margin: 0;
     }
 
     .contact-hero__form {
-        grid-column: 2 / 3;
-        grid-row: 1 / span 2;
-        justify-self: stretch;
         align-self: stretch;
-        max-width: 680px;
-        margin-top: 0;
     }
-
-    .contact-hero__form-inner {
-        height: 100%;
-    }
-}
-
-
-.contact-hero__info {
-    color: var(--color-heading);
-}
-
-.contact-hero__info-inner {
-    display: grid;
-    gap: clamp(1.5rem, 3vw, 2.25rem);
-    padding-block: clamp(0.25rem, 1.5vw, 1.5rem);
-    padding-inline: clamp(0rem, 1.5vw, 0.75rem);
-    justify-items: start;
-    text-align: left;
 }
 
 .contact-details {
@@ -1789,42 +1786,32 @@ a:focus {
 
 .contact-hero__form {
     position: relative;
-    border-radius: 22px;
-    background: rgba(58, 104, 153, 0.95);
-    box-shadow: 0 20px 42px rgba(58, 104, 153, 0.25);
+    border-radius: 24px;
+    background: linear-gradient(140deg, rgba(58, 104, 153, 0.98), rgba(102, 140, 186, 0.92));
+    box-shadow: 0 26px 48px rgba(58, 104, 153, 0.26);
     overflow: hidden;
     color: #f9f7ff;
-    width: 780px;
-    max-width: 100%;
-    margin-top: clamp(-0.5rem, 1.8vw, 0.75rem);
-}
-
-.contact-hero__content .contact-hero__form {
-    justify-self: center;
+    width: min(100%, 640px);
+    margin: clamp(0.5rem, 2vw, 1.25rem) auto 0;
 }
 
 @media (min-width: 960px) {
-    .contact-hero__content .contact-hero__form {
+    .contact-hero__form {
         justify-self: end;
+        margin: 0;
+        width: min(100%, 680px);
     }
 }
 
 @media (min-width: 1100px) {
-    .contact-hero__info-inner {
-        margin-top: -0.75rem;
-    }
-
     .contact-hero__form {
-        width: 820px;
-        max-width: 100%;
-        margin-top: clamp(-0.75rem, 1.2vw, 0.75rem);
-        margin-left: clamp(1.5rem, 4vw, 3rem);
+        margin-left: clamp(1.4rem, 3.8vw, 3rem);
     }
 }
 
 @media (min-width: 1440px) {
     .contact-hero__form {
-        margin-left: clamp(2.5rem, 6vw, 5rem);
+        margin-left: clamp(2.2rem, 5vw, 4.5rem);
     }
 }
 

--- a/contact.html
+++ b/contact.html
@@ -32,10 +32,10 @@
     <main>
         <section class="section contact-hero" aria-labelledby="contact-intro-title">
             <div class="contact-hero__container">
-                <div class="contact-hero__header">
-                    <h1 id="contact-intro-title">Get in touch</h1>
-                </div>
-                <div class="contact-hero__content">
+                <div class="contact-hero__details">
+                    <div class="contact-hero__header">
+                        <h1 id="contact-intro-title">Get in touch</h1>
+                    </div>
                     <div class="contact-hero__info">
                         <div class="contact-hero__info-inner">
                             <ul class="contact-details" role="list">
@@ -100,38 +100,38 @@
                             </div>
                         </div>
                     </div>
-                    <div class="contact-hero__form" aria-labelledby="contact-form-title">
-                        <div class="contact-hero__form-inner">
-                            <div class="contact-hero__form-heading">
-                                <h2 id="contact-form-title">Send us a message</h2>
-                            </div>
-                            <form class="contact-form" aria-label="Contact form" data-contact-form data-contact-email="contact@awarenet.org">
-                                <div class="form-field">
-                                    <label for="contact-name">Name</label>
-                                    <input type="text" id="contact-name" name="name" placeholder="Your name" required>
-                                </div>
-                                <div class="form-field">
-                                    <label for="contact-email">Email</label>
-                                    <input type="email" id="contact-email" name="email" placeholder="name@company.com" required>
-                                </div>
-                                <div class="form-field form-field--organization" data-organization-field>
-                                    <label for="contact-organization">University</label>
-                                    <div class="organization-select" data-organization-select>
-                                        <input type="text" id="contact-organization" name="organization" placeholder="Start typing to find your institution" autocomplete="off" data-organization-input aria-autocomplete="list" aria-expanded="false" aria-controls="organization-options" role="combobox">
-                                        <button type="button" class="organization-select__toggle" aria-label="Toggle organization list" aria-haspopup="listbox" aria-expanded="false" data-organization-toggle>
-                                            <span aria-hidden="true">&#9662;</span>
-                                        </button>
-                                        <div class="organization-select__list" id="organization-options" role="listbox" data-organization-list></div>
-                                    </div>
-                                </div>
-                                <div class="form-field">
-                                    <label for="contact-message">Message</label>
-                                    <textarea id="contact-message" name="message" rows="4" placeholder="Share your message" required></textarea>
-                                </div>
-                                <button type="submit" class="button">Send request</button>
-                                <p class="form-status" data-form-status role="status" aria-live="polite"></p>
-                            </form>
+                </div>
+                <div class="contact-hero__form" aria-labelledby="contact-form-title">
+                    <div class="contact-hero__form-inner">
+                        <div class="contact-hero__form-heading">
+                            <h2 id="contact-form-title">Send us a message</h2>
                         </div>
+                        <form class="contact-form" aria-label="Contact form" data-contact-form data-contact-email="contact@awarenet.org">
+                            <div class="form-field">
+                                <label for="contact-name">Name</label>
+                                <input type="text" id="contact-name" name="name" placeholder="Your name" required>
+                            </div>
+                            <div class="form-field">
+                                <label for="contact-email">Email</label>
+                                <input type="email" id="contact-email" name="email" placeholder="name@company.com" required>
+                            </div>
+                            <div class="form-field form-field--organization" data-organization-field>
+                                <label for="contact-organization">University</label>
+                                <div class="organization-select" data-organization-select>
+                                    <input type="text" id="contact-organization" name="organization" placeholder="Start typing to find your institution" autocomplete="off" data-organization-input aria-autocomplete="list" aria-expanded="false" aria-controls="organization-options" role="combobox">
+                                    <button type="button" class="organization-select__toggle" aria-label="Toggle organization list" aria-haspopup="listbox" aria-expanded="false" data-organization-toggle>
+                                        <span aria-hidden="true">&#9662;</span>
+                                    </button>
+                                    <div class="organization-select__list" id="organization-options" role="listbox" data-organization-list></div>
+                                </div>
+                            </div>
+                            <div class="form-field">
+                                <label for="contact-message">Message</label>
+                                <textarea id="contact-message" name="message" rows="4" placeholder="Share your message" required></textarea>
+                            </div>
+                            <button type="submit" class="button">Send request</button>
+                            <p class="form-status" data-form-status role="status" aria-live="polite"></p>
+                        </form>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
## Summary
- restructure the contact hero layout so the details and form remain balanced in side-by-side columns
- remove the boxed card styling from the contact details pane for a cleaner left column presentation

## Testing
- [x] Visual check (contact.html)


------
https://chatgpt.com/codex/tasks/task_e_68e7a3beb3b8832ba022524dae1754b3