### PR TITLE
Ensure team anchor clears sticky header

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -1626,9 +1626,9 @@ a:focus {
     max-width: none;
     margin: 0;
     width: 100%;
-    padding-top: clamp(2.5rem, 8vw, 4.5rem);
     padding-inline: clamp(1.5rem, 8vw, 6rem);
     position: relative;
+    scroll-margin-top: clamp(5rem, 12vw, 7rem);
 }
 
 .team-section--calm > * {


### PR DESCRIPTION
## Summary
- remove the reduced top padding override from the calm team section
- add scroll margin so anchor jumps land below the sticky header height

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e7a9016a04832b84569dfb946150fd