### PR TITLE
Adjust goals section spacing

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -777,6 +777,10 @@ a:focus {
 }
 
 
+.section--goals {
+    gap: clamp(1.75rem, 3vw, 2.25rem);
+}
+
 .section--goals .section__heading {
     max-width: 100%;
 }


### PR DESCRIPTION
## Summary
- reduce the vertical gap in the goals section to bring the objective cards closer to the heading

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e7acbd4a00832bb49b71f1e0b90672