### PR TITLE
Add accent divider to event cards

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -1408,6 +1408,15 @@ a:focus {
     font-size: 1rem;
 }
 
+.event-card__divider {
+    display: block;
+    width: 3.25rem;
+    height: 0.25rem;
+    background: var(--color-heading);
+    border-radius: 999px;
+    margin-top: 0.15rem;
+}
+
 .highlight-card__description {
     margin: 0;
     color: var(--color-text);

--- a/news.html
+++ b/news.html
@@ -46,6 +46,7 @@
                                 <a href="events/retreat-2025.html">Retreat 2025</a>
                             </h2>
                             <p class="highlight-card__date">16 October 2025</p>
+                            <span class="event-card__divider" aria-hidden="true"></span>
                         </div>
                         <p class="highlight-card__description">Annual Retreat of the CNR Institute of Neuroscience in Parma.</p>
                     </div>
@@ -80,6 +81,7 @@
                                     <a href="events/retreat-2025.html">Retreat 2025</a>
                                 </h3>
                                 <p class="news-card__date news-card__date--upcoming"><strong>16 October 2025</strong></p>
+                                <span class="event-card__divider" aria-hidden="true"></span>
                                 <p class="news-card__description">Annual Retreat of the CNR Institute of Neuroscience in Parma</p>
                             </div>
                         </article>
@@ -92,6 +94,7 @@
                                     <a href="events/retreat-2025.html">Retreat 2025</a>
                                 </h3>
                                 <p class="news-card__date news-card__date--upcoming"><strong>16 October 2025</strong></p>
+                                <span class="event-card__divider" aria-hidden="true"></span>
                                 <p class="news-card__description">Annual Retreat of the CNR Institute of Neuroscience in Parma</p>
                             </div>
                         </article>
@@ -111,6 +114,7 @@
                                     <a href="parma_retreat.html">Retreat 2025</a>
                                 </h3>
                                 <p class="news-card__date news-card__date--upcoming"><strong>16 October 2025</strong></p>
+                                <span class="event-card__divider" aria-hidden="true"></span>
                                 <p class="news-card__description">Annual Retreat of the CNR Institute of Neuroscience in Parma</p>
                             </div>
                         </article>


### PR DESCRIPTION
## Summary
- add reusable accent divider element for event-style cards
- insert divider below event dates in highlight and archive cards on the news page
- align the divider color with the "Latest highlights" heading

## Testing
- no automated tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68e7ab3fc270832b977e8ae49f71a937