### PR TITLE
Fix team section anchor offset

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -1649,6 +1649,10 @@ a:focus {
     gap: 2.5rem;
 }
 
+#team-section {
+    scroll-margin-top: calc(var(--header-offset) + 2rem);
+}
+
 .team-section--calm {
     background: transparent;
     color: var(--color-text);


### PR DESCRIPTION
## Summary
- add scroll margin to the team section so in-page navigation leaves space for the sticky header

## Testing
- no tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68e7abc22c60832b9b92a85f149106f0