### PR TITLE
Adjust team spacing and portrait sizes

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -1698,7 +1698,7 @@ a:focus {
 .team-grid {
     display: grid;
     grid-template-columns: repeat(4, minmax(0, 1fr));
-    gap: clamp(1.5rem, 3vw, 2.25rem);
+    gap: clamp(1.15rem, 2.4vw, 1.85rem);
 }
 
 .team-card {
@@ -1714,7 +1714,7 @@ a:focus {
 }
 
 .team-card__figure {
-    --team-card-portrait-size: clamp(9.5rem, 62%, 12.25rem);
+    --team-card-portrait-size: clamp(10.25rem, 68%, 13rem);
     margin: 0;
     display: grid;
     place-items: center;


### PR DESCRIPTION
## Summary
- reduce the gaps between team member cards to bring them closer together while keeping four columns
- slightly enlarge the portrait size so each person appears more prominent

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e7abdd4a94832b8ec5b7bb6798f1ff