### PR TITLE
Adjust research hero background

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -391,6 +391,22 @@ a:focus {
     z-index: 1;
 }
 
+.section--hero.section--hero--clear {
+    color: var(--color-heading);
+}
+
+.section--hero.section--hero--clear::before {
+    display: none;
+}
+
+.section--hero.section--hero--clear h1 {
+    color: var(--color-title-strong);
+}
+
+.section--hero.section--hero--clear p {
+    color: var(--color-text);
+}
+
 .hero__inner {
     position: relative;
     z-index: 2;

--- a/research.html
+++ b/research.html
@@ -31,7 +31,7 @@
     </header>
 
     <main>
-        <section class="section section--hero" aria-labelledby="research-hero-title">
+        <section class="section section--hero section--hero--clear" aria-labelledby="research-hero-title">
             <div class="section__content">
                 <h1 id="research-hero-title">Interdisciplinary research that keeps humans in the loop</h1>
                 <p>We develop reliable tools inspired by neuroscience to make artificial intelligence interpretable, measurable, and trustworthy.</p>


### PR DESCRIPTION
## Summary
- remove the hero overlay from the research page hero section so the main page background shows through
- update typography colors within the research hero to match the light background

## Testing
- no tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68e7b0695d7c832bbf4a6cb8b32acda4