### PR TITLE
Refine partner hero left alignment and CTA spacing

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -539,9 +539,10 @@ a:focus {
     align-items: start;
     width: min(100%, var(--layout-fluid-width));
     margin: 0 auto;
-    padding-inline: clamp(1.5rem, 6vw, 4rem);
+    padding-left: clamp(0.5rem, 3vw, 2rem);
+    padding-right: clamp(2rem, 7vw, 4.5rem);
     box-sizing: border-box;
-    justify-content: center;
+    justify-content: start;
 }
 
 .hero-institutions__content {
@@ -553,7 +554,7 @@ a:focus {
 
 .hero-institutions h1 {
     color: #1b2c4d;
-    font-size: clamp(2.5rem, 5vw, 3.6rem);
+    font-size: clamp(2.8rem, 5.5vw, 4.25rem);
     letter-spacing: -0.01em;
     margin: 0;
     white-space: normal;
@@ -568,7 +569,7 @@ a:focus {
 }
 
 .hero-institutions .hero-institutions__cta {
-    margin-top: 1.5rem;
+    margin-top: clamp(2.25rem, 4vw, 3rem);
     text-transform: none;
     background: #1b2c4d;
     color: #f4f7ff;


### PR DESCRIPTION
## Summary
- reduce the left padding on the partner hero layout so the heading sits closer to the page edge
- increase the CTA's top margin to create more separation from the heading without enlarging the button

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e7afca0da0832ba2e2399d3ebd50d9