### PR TITLE
Adjust hero institutions layout on team page

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -467,7 +467,7 @@ a:focus {
     overflow: hidden;
     background: linear-gradient(180deg, #f8f9ff 0%, #f1f0fb 55%, #f5ede7 100%);
     color: var(--color-text);
-    padding: clamp(6rem, 18vh, 8.5rem) 0 clamp(4rem, 14vh, 6.5rem);
+    padding: clamp(4.75rem, 16vh, 7.5rem) 0 clamp(4rem, 14vh, 6.5rem);
     margin-top: 0;
 }
 
@@ -553,7 +553,7 @@ a:focus {
     position: relative;
     z-index: 2;
     display: grid;
-    gap: clamp(2.2rem, 4vw, 3.5rem);
+    gap: clamp(3rem, 6vw, 4.5rem);
     align-items: start;
     width: min(100%, var(--layout-fluid-width));
     margin: 0 auto;
@@ -690,26 +690,28 @@ a:focus {
 
 @media (min-width: 900px) {
     .hero-institutions__layout {
-        grid-template-columns: minmax(320px, 420px) minmax(340px, 480px);
-        align-items: start;
-        column-gap: clamp(3.75rem, 8vw, 5.5rem);
+        grid-template-columns: minmax(320px, 1fr) minmax(340px, 1fr);
+        align-items: center;
+        column-gap: clamp(4rem, 8vw, 6rem);
     }
 
     .hero-institutions__content {
-        justify-items: end;
-        text-align: right;
-        padding-inline-end: clamp(1.25rem, 4vw, 2.75rem);
-        margin-top: clamp(-1rem, -2.5vw, -0.5rem);
+        justify-items: start;
+        text-align: left;
+        padding-inline-end: 0;
+        margin-top: 0;
     }
 
     .hero-institutions .hero-institutions__cta {
-        justify-self: end;
+        justify-self: start;
         margin-top: clamp(2.25rem, 4vw, 3rem);
     }
 
     .hero-institutions__logos {
-        align-self: start;
-        margin-top: clamp(-2.5rem, -5vw, -1.75rem);
+        justify-content: flex-end;
+        justify-self: end;
+        align-self: center;
+        margin-top: 0;
     }
 }
 


### PR DESCRIPTION
## Summary
- realign the partner institutions hero content and logos so the logos sit on the right
- increase spacing between the hero heading and partner cards for improved separation
- raise the hero institutions grid higher on the page by reducing top padding

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68e7be5b2f74832b8e5baf6ec2888d53