### PR TITLE
Align contact page header typography

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -154,10 +154,6 @@ body {
     line-height: 1.6;
 }
 
-body.contact-page {
-    font-size: clamp(15px, 1.2vw, 16px);
-}
-
 .contact-page .navbar {
     padding: 0.5rem 1.25rem;
     gap: 1.1rem;
@@ -173,16 +169,8 @@ body.contact-page {
     height: 3rem;
 }
 
-.contact-page .navbar__title {
-    font-size: clamp(1.45rem, 1.6vw + 0.95rem, 1.95rem);
-}
-
 .contact-page .navbar__menu {
     gap: 1.25rem;
-}
-
-.contact-page .navbar__link {
-    font-size: 0.88rem;
 }
 
 img {


### PR DESCRIPTION
## Summary
- remove contact-page specific font-size overrides so the header typography matches other pages

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e7d1c5c078832b83508cba37c3188e