### PR TITLE
Adjust hero institutions alignment on team page

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -668,7 +668,7 @@ a:focus {
         justify-items: end;
         text-align: right;
         padding-inline-end: clamp(1.25rem, 4vw, 2.75rem);
-        margin-top: clamp(-1rem, -2.5vw, -0.5rem);
+        margin-top: clamp(-3.5rem, -6vw, -2.25rem);
     }
 
     .hero-institutions .hero-institutions__cta {
@@ -678,7 +678,8 @@ a:focus {
 
     .hero-institutions__logos {
         align-self: start;
-        margin-top: clamp(-2.5rem, -5vw, -1.75rem);
+        margin-top: clamp(-4rem, -7vw, -2.75rem);
+        transform: translateX(clamp(1rem, 4vw, 2.75rem));
     }
 }
 


### PR DESCRIPTION
## Summary
- raise the hero title block on the team page so it aligns with the partner logos
- lift and slightly shift the partner logo grid to sit on the same visual axis as the heading on wide viewports

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68e7d96e2d5c832b8fd1bb2a76b7fb3a