### PR TITLE
Standardize fluid paragraph typography

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -34,6 +34,7 @@ html {
     --layout-max-width: 1200px;
     --layout-fluid-width: min(92vw, var(--layout-max-width));
     --layout-section-padding: clamp(1.5rem, 5vw, 3.5rem);
+    --font-size-body: clamp(1.02rem, 0.96rem + 0.22vw, 1.18rem);
 }
 
 @media (min-width: 1360px) {
@@ -148,10 +149,15 @@ body {
     display: flex;
     flex-direction: column;
     font-family: var(--font-family);
-    font-size: 1.3125rem;
+    font-size: var(--font-size-body);
     color: var(--color-text);
     background: var(--gradient-background);
-    line-height: 1.6;
+    line-height: 1.65;
+}
+
+p {
+    font-size: 1em;
+    line-height: inherit;
 }
 
 img {
@@ -427,7 +433,6 @@ a:focus {
 
 .section--hero p {
     color: rgba(244, 245, 255, 0.88);
-    font-size: clamp(1.05rem, 1.4vw, 1.3rem);
     max-width: none;
 }
 
@@ -550,7 +555,6 @@ a:focus {
 
 .hero-institutions__content p {
     color: #43526b;
-    font-size: clamp(1.15rem, 2.4vw, 1.35rem);
     max-width: 36rem;
     line-height: 1.6;
 }
@@ -770,12 +774,12 @@ a:focus {
 .section__heading p {
     margin: 0;
     color: var(--color-muted);
-    font-size: clamp(1.06rem, 1.8vw, 1.25rem);
 }
 
 .section__heading .section__lead {
-    font-size: clamp(1.17rem, 2.45vw, 1.44rem);
-    line-height: 1.6;
+    font-size: inherit;
+    line-height: 1.65;
+    font-weight: 500;
 }
 
 .highlights .section__heading {
@@ -783,7 +787,7 @@ a:focus {
 }
 
 .highlights .section__heading p {
-    font-size: 1.2rem;
+    font-size: inherit;
 }
 
 
@@ -875,7 +879,7 @@ a:focus {
 .objective-card__text {
     margin: 0;
     color: var(--color-muted);
-    font-size: clamp(1.08rem, 2vw, 1.3rem);
+    font-size: inherit;
     text-align: center;
 }
 
@@ -920,7 +924,6 @@ a:focus {
     margin: 0;
     max-width: 48ch;
     color: var(--color-muted);
-    font-size: clamp(1.12rem, 2.2vw, 1.35rem);
 }
 
 .about-layout__highlights {
@@ -978,7 +981,6 @@ a:focus {
 .about-highlight p {
     margin: 0;
     color: var(--color-muted);
-    font-size: clamp(1.1rem, 2vw, 1.32rem);
 }
 
 .about-highlight__link {
@@ -1020,7 +1022,7 @@ a:focus {
 }
 
 .section--cta .section__heading .section__lead {
-    font-size: clamp(1.16rem, 2.3vw, 1.42rem);
+    font-size: inherit;
 }
 
 .cta-button {
@@ -1092,7 +1094,6 @@ a:focus {
     margin: 0;
     color: rgba(37, 38, 58, 0.72);
     line-height: 1.6;
-    font-size: clamp(1.05rem, 2vw, 1.22rem);
 }
 
 .contact-hero__info {
@@ -1461,7 +1462,7 @@ a:focus {
     margin: 0;
     color: var(--color-text);
     line-height: 1.5;
-    font-size: 0.95rem;
+    font-size: inherit;
     font-weight: 400;
 }
 
@@ -1596,7 +1597,7 @@ a:focus {
 .news-card__description {
     margin: 0;
     color: var(--color-text);
-    font-size: 0.9rem;
+    font-size: inherit;
     font-weight: 400;
 }
 
@@ -1920,7 +1921,7 @@ a:focus {
 .contact-hero__form-heading p {
     margin: 0;
     color: rgba(249, 247, 255, 0.85);
-    font-size: 0.95rem;
+    font-size: inherit;
     line-height: 1.55;
 }
 
@@ -2169,7 +2170,7 @@ a:focus {
 
 .hero-highlight p {
     margin: 0 0 0.75rem;
-    font-size: 1rem;
+    font-size: inherit;
 }
 
 .hero-highlight p:last-child {


### PR DESCRIPTION
## Summary
- add a fluid base font-size custom property for body copy and apply it sitewide
- update section and card paragraph styles to inherit the shared body typography for consistent sizing

## Testing
- not run (not required)


------
https://chatgpt.com/codex/tasks/task_e_68e7dd9b4d04832bb54ad7d9958e6f14