### PR TITLE
Adjust goals section spacing

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -795,7 +795,7 @@ a:focus {
 
 
 .section--goals {
-    gap: clamp(1.75rem, 3vw, 2.25rem);
+    gap: clamp(1.25rem, 2.5vw, 1.75rem);
 }
 
 .section--goals .section__heading {


### PR DESCRIPTION
## Summary
- decrease the vertical gap between the Our Goals subtitle and the goal cards to pull the cards higher on the page

## Testing
- no tests were run

------
https://chatgpt.com/codex/tasks/task_e_68e8c94e8944832bbb99b80c4810608e