### PR TITLE
Ensure Research hero section covers full viewport

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -2354,9 +2354,14 @@ main {
 
 .research-hero {
     padding: clamp(4rem, 12vw, 6rem) var(--layout-section-padding);
-    display: grid;
-    place-items: center;
-    background: var(--color-background);
+    min-height: 100vh;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: var(--gradient-background);
+    background-size: cover;
+    background-repeat: no-repeat;
+    background-position: center;
     border-bottom: 1px solid rgba(58, 104, 153, 0.12);
 }
 


### PR DESCRIPTION
## Summary
- make the research hero section fill the viewport height and center its content
- update the hero background treatment to use the page gradient so it covers the full screen

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e8c97e84c0832b81865819e6ba8ee7