### PR TITLE
Improve Explore more scroll centering

### DIFF
--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -31,8 +31,18 @@ document.addEventListener('DOMContentLoaded', () => {
         const headerHeight = header ? header.getBoundingClientRect().height : 0;
         const dynamicSpacing = headerHeight * 0.75; // Use a portion of the header height to create consistent breathing room
 
-        const targetPosition = target.getBoundingClientRect().top + window.pageYOffset;
-        const offsetPosition = Math.max(0, targetPosition - headerHeight - dynamicSpacing);
+        const focusTarget = target.closest('[data-scroll-focus]') || target;
+        const focusRect = focusTarget.getBoundingClientRect();
+        const focusHeight = focusRect.height;
+        const viewportHeight = window.innerHeight || document.documentElement.clientHeight;
+        const availableHeight = Math.max(0, viewportHeight - headerHeight);
+        const centeringOffset = Math.max(
+            dynamicSpacing,
+            availableHeight > 0 ? Math.max(0, (availableHeight - focusHeight) / 2) : 0
+        );
+
+        const focusPosition = focusRect.top + window.pageYOffset;
+        const offsetPosition = Math.max(0, focusPosition - headerHeight - centeringOffset);
 
         window.scrollTo({ top: offsetPosition, behavior: 'smooth' });
     };

--- a/index.html
+++ b/index.html
@@ -45,7 +45,7 @@
 
         <section class="section section--surface section--about" aria-labelledby="about-title">
             <div class="about-layout">
-                <div class="about-layout__intro">
+                <div class="about-layout__intro" data-scroll-focus>
                     <h2 id="about-title">What is AWARENET?</h2>
                     <p>AWARENET maps how the brain generates and organizes consciousness, combining intracranial recordings, brain imaging, and computational modeling to link neural activity with clinical outcomes.</p>
                 </div>


### PR DESCRIPTION
## Summary
- center the "What is AWARENET?" block when navigating via in-page anchors
- tag the about-section intro as the focus target for scroll positioning

## Testing
- python3 -m http.server 8000 (manual)


------
https://chatgpt.com/codex/tasks/task_e_68e8c9e66a70832baeab241a2bb804cf