### PR TITLE
Align research text sizing with index page

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -2381,7 +2381,7 @@ main {
 }
 
 .research-hero__lead {
-    font-size: clamp(1rem, 1.8vw, 1.2rem);
+    font-size: var(--font-size-body);
     line-height: 1.6;
     color: var(--color-text);
 }
@@ -2420,7 +2420,7 @@ main {
 .research-intro {
     max-width: min(880px, 100%);
     color: var(--color-text);
-    font-size: 1rem;
+    font-size: var(--font-size-body);
     line-height: 1.7;
 }
 
@@ -2509,7 +2509,7 @@ main {
 .research-impact__list {
     display: grid;
     gap: 0.75rem;
-    font-size: 1rem;
+    font-size: var(--font-size-body);
     color: var(--color-text);
     padding-left: 1.2rem;
 }
@@ -2520,7 +2520,7 @@ main {
 
 .research-collab p {
     max-width: min(720px, 100%);
-    font-size: 1rem;
+    font-size: var(--font-size-body);
     line-height: 1.7;
     color: var(--color-text);
 }
@@ -2548,7 +2548,7 @@ main {
 
 .research-cta__card p {
     color: var(--color-text);
-    font-size: 1rem;
+    font-size: var(--font-size-body);
 }
 
 .research-cta__actions {


### PR DESCRIPTION
## Summary
- update research page typography to reuse the global body font size
- ensure introductory, impact, collaboration, and call-to-action text matches index page proportions

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e8ca421eec832b8084fb33258de4e8