### PR TITLE
Adjust research hero layout and color

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -2353,10 +2353,11 @@ main {
 }
 
 .research-hero {
-    padding: clamp(4rem, 12vw, 6rem) var(--layout-section-padding);
+    padding-block: clamp(3.5rem, 10vw, 5rem) clamp(5rem, 14vw, 7rem);
+    padding-inline: var(--layout-section-padding);
     min-height: 100vh;
     display: flex;
-    align-items: center;
+    align-items: flex-start;
     justify-content: center;
     background: var(--gradient-background);
     background-size: cover;
@@ -2369,7 +2370,7 @@ main {
     margin: 0;
     font-size: clamp(2rem, 4.5vw, 2.8rem);
     line-height: 1.15;
-    color: var(--color-title-strong);
+    color: #1b2c4d;
 }
 
 .research-hero__grid {
@@ -2564,6 +2565,10 @@ main {
 }
 
 @media (max-width: 960px) {
+    .research-hero {
+        align-items: center;
+    }
+
     .research-hero__grid {
         grid-template-columns: 1fr;
         text-align: center;
@@ -2584,7 +2589,8 @@ main {
 
 @media (max-width: 640px) {
     .research-hero {
-        padding: clamp(3rem, 14vw, 4rem) var(--layout-section-padding);
+        padding-block: clamp(2.5rem, 12vw, 3.5rem) clamp(3.5rem, 16vw, 4.5rem);
+        padding-inline: var(--layout-section-padding);
     }
 
     .research-task,


### PR DESCRIPTION
## Summary
- lift the research hero layout by reducing top padding and aligning the grid toward the top on wide screens while retaining centered layout on mobile
- update responsive rules to keep comfortable spacing on small viewports
- match the research hero heading color to the dark blue used across other section titles for consistency

## Testing
- Visual check of `research.html`


------
https://chatgpt.com/codex/tasks/task_e_68e8d0927068832b99031474c9db6adf