### PR TITLE
Center research hero content vertically

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -2361,7 +2361,7 @@ main {
     padding-inline: var(--layout-section-padding);
     min-height: 100vh;
     display: flex;
-    align-items: flex-start;
+    align-items: center;
     justify-content: center;
     background: var(--gradient-background);
     background-size: cover;


### PR DESCRIPTION
## Summary
- center the research hero section vertically within the viewport so the header sits in the middle of the page

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e8d3c152b0832b9b9d4cc3a2ece759