### PR TITLE
Shorten hero section and simplify anchor scroll

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -352,7 +352,7 @@ a:focus {
     align-items: center;
     justify-content: center;
     padding: clamp(2.25rem, 10vh, 5.5rem) clamp(1.5rem, 8vw, 6rem);
-    min-height: 100vh;
+    min-height: clamp(26rem, 78vh, 92vh);
     width: 100%;
     max-width: none;
     margin: 0;

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -17,18 +17,9 @@ if (toggleButton && navigation) {
 }
 
 document.addEventListener('DOMContentLoaded', () => {
-    const getHeaderOffset = () => {
+    const getHeaderHeight = () => {
         const header = document.querySelector('.site-header');
-        if (!header) {
-            return 0;
-        }
-
-        const rect = header.getBoundingClientRect();
-        const styles = window.getComputedStyle(header);
-        const marginTop = parseFloat(styles.marginTop) || 0;
-        const marginBottom = parseFloat(styles.marginBottom) || 0;
-
-        return rect.height + marginTop + marginBottom;
+        return header ? header.getBoundingClientRect().height : 0;
     };
 
     const scrollWithOffset = (hash) => {
@@ -41,22 +32,10 @@ document.addEventListener('DOMContentLoaded', () => {
             return;
         }
 
-        const headerOffset = getHeaderOffset();
-        const targetRect = target.getBoundingClientRect();
-        const targetTop = targetRect.top + window.pageYOffset;
-        const targetStyles = window.getComputedStyle(target);
-        const scrollMarginTop = parseFloat(targetStyles.scrollMarginTop) || 0;
-        const breathingSpace = Math.max(0, scrollMarginTop - headerOffset);
-
-        const focusContainer = target.closest('[data-scroll-focus]') || target;
-        const section = focusContainer.closest('section') || focusContainer;
-        const sectionRect = section.getBoundingClientRect();
-        const sectionTop = sectionRect.top + window.pageYOffset;
-        const minimumOffset = sectionTop - headerOffset;
-
-        let offsetPosition = targetTop - headerOffset - breathingSpace;
-        offsetPosition = Math.max(offsetPosition, minimumOffset);
-        offsetPosition = Math.max(0, Math.round(offsetPosition));
+        const headerHeight = getHeaderHeight();
+        const dynamicSpacing = headerHeight * 0.75;
+        const targetPosition = target.getBoundingClientRect().top + window.pageYOffset;
+        const offsetPosition = Math.max(0, targetPosition - headerHeight - dynamicSpacing);
 
         window.scrollTo({ top: offsetPosition, behavior: 'smooth' });
     };


### PR DESCRIPTION
## Summary
- reduce the homepage hero section height with a responsive clamp so the about section aligns naturally
- revert the anchor scrolling logic to the previous header-height based offset for consistent behavior

## Testing
- not run (static content change)


------
https://chatgpt.com/codex/tasks/task_e_68e8dfc26d70832b87f3b90818ab2f84