### PR TITLE
Adjust hero background to span full viewport

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -353,9 +353,10 @@ a:focus {
     justify-content: center;
     padding: clamp(2.25rem, 10vh, 5.5rem) clamp(1.5rem, 8vw, 6rem);
     min-height: clamp(26rem, 78vh, 92vh);
-    width: 100%;
+    width: min(100vw, 100%);
     max-width: none;
-    margin: 0;
+    margin-left: calc((100vw - 100%) / -2);
+    margin-right: calc((100vw - 100%) / -2);
     overflow: hidden;
     color: white;
 }


### PR DESCRIPTION
## Summary
- let hero sections expand to the viewport width so their media fills the screen edge to edge
- compensate with calculated margins so full-bleed sections do not create horizontal scroll

## Testing
- no tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68e8e3ea6d54832b807e77f8a03d58ec