### PR TITLE
Adjust team hero section to fill viewport height

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -445,6 +445,7 @@ a:focus {
     color: var(--color-text);
     padding: clamp(5rem, 16vh, 7.5rem) 0 clamp(4rem, 14vh, 6.5rem);
     margin-top: 0;
+    min-height: 100vh;
 }
 
 .hero-institutions::before {


### PR DESCRIPTION
## Summary
- ensure the team page hero section maintains a full viewport height so its gradient background reaches the bottom edge

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e8e4200224832bb705314347b108de