### PR TITLE
Fix smooth scrolling for team anchor links

### DIFF
--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -22,7 +22,7 @@ document.addEventListener('DOMContentLoaded', () => {
         return header ? header.getBoundingClientRect().height : 0;
     };
 
-    const scrollWithOffset = (hash) => {
+    const scrollToHash = (hash) => {
         if (!hash || hash === '#') {
             return;
         }


### PR DESCRIPTION
## Summary
- rename the smooth-scroll helper so in-page anchor links resolve correctly
- restore "Meet the team" button functionality on the team page

## Testing
- Manual verification in browser

------
https://chatgpt.com/codex/tasks/task_e_68e8f4810260832bb1b2ee5349bf476c