### PR TITLE
Restore centered mission narrative on research page

### DIFF
--- a/research.html
+++ b/research.html
@@ -36,121 +36,60 @@
                     <h1 id="research-hero-title">Interdisciplinary research that keeps humans in the loop</h1>
                 </div>
                 <figure class="research-hero__figure" role="img" aria-label="Brain maps of complexity, tonicity, and functional gradient warped into a common space">
-                        <img src="" alt="Warping" loading="lazy">
+                        <img src="assets/images/research/warping.png" alt="Warping consciousness into a common space" loading="lazy">
                 </figure>
             </div>
         </section>
 
-        <section id="research-intro" class="section research-intro" aria-labelledby="research-intro-title">
+        <section id="research-mission" class="section research-intro" aria-labelledby="research-mission-title">
             <div class="section__header">
-                <h2 id="research-intro-title">Mission</h2>
+                <h2 id="research-mission-title">Mission</h2>
             </div>
-            <p>Consciousness has both <strong>levels</strong> (e.g., wakefulness, sleep) and <strong>contents</strong> (what we perceive). These dimensions have rarely been mapped together in the human brain. AWARENET builds a unified atlas of neural correlates—combining <strong>complexity</strong> for level and <strong>tonicity</strong> for content—from intracranial recordings. We align these maps with the brain’s large-scale organization and use lesion disconnectomes to predict how focal damage may alter awareness. Our goal is a practical, open tool to inform clinical decisions.</p>
+            <p>Understanding how the brain gives rise to consciousness remains one of neuroscience’s greatest challenges. Consciousness has both <strong>levels</strong> (e.g., wakefulness, sleep) and <strong>contents</strong> (what we perceive), dimensions that have rarely been mapped together in the human brain.</p>
+            <p>AWARENET draws on intracranial recordings to build a unified Awareness Atlas, align it with the brain’s large-scale organization, model how lesion disconnectomes may alter awareness, and translate these insights into clinical tools across stroke, epilepsy, coma, and vegetative state.</p>
+            <p>The atlas integrates:</p>
+            <ul>
+                <li>Perturbational Complexity Index (PCI) – level of consciousness</li>
+                <li>Tonicity index – content of consciousness</li>
+                <li>Functional gradients – large-scale cortical organization</li>
+            </ul>
         </section>
 
-        <section id="research-what" class="section research-dual" aria-labelledby="research-what-title">
+        <section id="research-challenges" class="section" aria-labelledby="research-challenges-title">
             <div class="section__header">
-                <h2 id="research-what-title">Mission</h2>
-                <p class="section__subhead">Two sides of awareness</p>
+                <h2 id="research-challenges-title">Main challenges</h2>
             </div>
-            <div class="research-dual__grid">
-                <article class="research-dual__item">
-                    <h3>Levels (Complexity)</h3>
-                    <p>How richly activity spreads after a small, controlled perturbation.</p>
-                </article>
-                <article class="research-dual__item">
-                    <h3>Contents (Tonicity)</h3>
-                    <p>How long responses persist when processing sensory input.</p>
-                </article>
-                <article class="research-dual__item research-dual__item--full">
-                    <h3>Together</h3>
-                    <p>Seeing both on the same cortical canvas reveals where level and content converge or diverge.</p>
-                </article>
-            </div>
+            <p>Our dataset relies on intracranial recordings (sEEG) from drug-resistant epilepsy patients, providing high spatial and temporal resolution but no direct fMRI data, raising a key question: <strong>How can we link functional connectivity with consciousness when no direct fMRI is available?</strong></p>
+            <p>To overcome this limitation, we:</p>
+            <ul>
+                <li>Embed individual lesions into normative connectomes, enabling indirect mapping of disconnection.</li>
+                <li>Combine structural (dMRI) and functional (fMRI) gradients from healthy populations.</li>
+                <li>Develop predictive models linking lesion impact to consciousness loss and recovery.</li>
+            </ul>
         </section>
 
-        <section id="research-how" class="section research-dual" aria-labelledby="research-how-title">
+        <section id="research-whatwedo" class="section" aria-labelledby="research-whatwedo-title">
             <div class="section__header">
-                <h2 id="research-how-title">How we study it</h2>
+                <h2 id="research-whatwedo-title">What we aim to do</h2>
             </div>
-            <div class="research-dual__grid research-dual__grid--list">
-                <article class="research-dual__item">
-                    <h3>SEEG + hdEEG</h3>
-                    <p>Precise intracranial recordings paired with scalp coverage enable brain-wide readouts of <strong>perturbational complexity</strong>.</p>
-                </article>
-                <article class="research-dual__item">
-                    <h3>No-report sensory mapping</h3>
-                    <p>Estimate <strong>tonicity</strong> across modalities without behavioral reports.</p>
-                </article>
-                <article class="research-dual__item">
-                    <h3>Common space</h3>
-                    <p>Warp both atlases onto <strong>functional and structural gradients</strong> from 7T HCP data to understand network context.</p>
-                </article>
-            </div>
+            <p>AWARENET will:</p>
+            <ul>
+                <li>Map brain regions supporting level and content of consciousness through intracranial perturbations and recordings (sEEG).</li>
+                <li>Integrate these maps with large-scale cortical gradients derived from normative fMRI/dMRI datasets (HCP 7T).</li>
+                <li>Test causality by studying patients undergoing controlled thermocoagulation lesions, comparing behavioral decline with disconnection-overlap in the atlas.</li>
+                <li>Develop tools that predict how specific lesions alter awareness, bridging basic and clinical neuroscience.</li>
+            </ul>
         </section>
 
         <section id="research-workflow" class="section research-workflow" aria-labelledby="research-workflow-title">
             <div class="section__header">
                 <h2 id="research-workflow-title">Workflow</h2>
             </div>
+            <p>From patient enrollment and intracranial recordings to atlas construction and predictive modeling, AWARENET integrates multiscale data into a unified framework.</p>
             <figure class="research-workflow__figure">
-                <div class="research-workflow__illustration" role="img" aria-label="Workflow from enrollment and recordings to atlases, gradients, and predictive tool"></div>
-                <figcaption>From patient enrollment and recordings to atlas building, alignment with brain gradients, and predictive tools for lesion effects.</figcaption>
+                <div class="research-workflow__illustration" role="img" aria-label="Workflow diagram outlining tasks from building PCI and tonicity maps to predictive modeling"></div>
+                <figcaption>Workflow of the project methodology. Tasks 1–2: build PCI and tonicity maps; Task 3: situate them within large-scale gradients; Task 4: develop predictive models of lesion impact.</figcaption>
             </figure>
-        </section>
-
-        <section id="research-tasks" class="section research-tasks" aria-labelledby="research-tasks-title">
-            <div class="section__header">
-                <h2 id="research-tasks-title">Tasks at a glance</h2>
-            </div>
-            <div class="research-tasks__grid">
-                <article class="research-task">
-                    <h3>T1 — Complexity Atlas</h3>
-                    <p>Build a cortex-wide map of perturbational complexity (PCI-like) from SEEG-SPES with hdEEG.</p>
-                </article>
-                <article class="research-task">
-                    <h3>T2 — Tonicity Atlas</h3>
-                    <p>Map sustained sensory responses across modalities and compare with complexity.</p>
-                </article>
-                <article class="research-task">
-                    <h3>T3 — Network Organization</h3>
-                    <p>Warp both atlases onto cortical gradients (fMRI/dMRI) and study network coupling.</p>
-                </article>
-                <article class="research-task">
-                    <h3>T4 — Predictive Tool</h3>
-                    <p>Use lesion disconnectomes to predict awareness-related deficits; release an open model and code.</p>
-                </article>
-            </div>
-        </section>
-
-        <section id="research-impact" class="section research-impact" aria-labelledby="research-impact-title">
-            <div class="section__header">
-                <h2 id="research-impact-title">Why it matters</h2>
-            </div>
-            <ul class="research-impact__list">
-                <li>A first unified atlas linking level and content of consciousness in humans.</li>
-                <li>Anticipate lesion-related awareness deficits before interventions.</li>
-                <li>Open resources to accelerate validation and clinical translation.</li>
-            </ul>
-        </section>
-
-        <section id="research-collab" class="section research-collab" aria-labelledby="research-collab-title">
-            <div class="section__header">
-                <h2 id="research-collab-title">Collaboration &amp; openness</h2>
-            </div>
-            <p>We bring together IN-CNR, UNIPD, UNIMI, and clinical partners at Niguarda. Results, code, and atlases will be openly released to maximize impact and reproducibility.</p>
-        </section>
-
-        <section id="research-cta" class="section research-cta" aria-labelledby="research-cta-title">
-            <span id="contact" class="visually-hidden" aria-hidden="true"></span>
-            <div class="research-cta__card">
-                <h3 id="research-cta-title">Work with us</h3>
-                <p>We collaborate with hospitals, research groups, and companies to turn awareness science into better care.</p>
-                <div class="research-cta__actions">
-                    <a class="button" href="#contact">Contact us</a>
-                    <a class="button button--secondary" href="team.html">Learn more</a>
-                </div>
-            </div>
         </section>
     </main>
 


### PR DESCRIPTION
## Summary
- present the Mission section using the centered overview layout without the side image so the intro flows linearly
- keep the Awareness Atlas bullet points beneath the mission narrative to highlight the key integration elements

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e8ebdba350832b9166e34364d727f4