### PR TITLE
Increase spacing before about section

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -901,6 +901,7 @@ a:focus {
 .section--about {
     position: relative;
     max-width: var(--layout-fluid-width);
+    margin-top: clamp(3rem, 9vw, 6rem);
 }
 
 #about-title {


### PR DESCRIPTION
## Summary
- add extra top spacing before the about section to provide more separation from the hero when clicking "Explore more"

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68e96a7bc390832b8227b5f7aa1ffe5b