### PR TITLE
Reduce spacing between research section headings and content

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -334,7 +334,18 @@ a:focus {
     max-width: var(--layout-fluid-width);
     margin: 0 auto;
     display: grid;
-    gap: 2.5rem;
+    gap: clamp(1.15rem, 2.5vw, 1.75rem);
+}
+
+.section > p,
+.section > ul,
+.section > ol {
+    margin: 0;
+}
+
+.section > ul,
+.section > ol {
+    padding-left: 1.25rem;
 }
 
 .section--surface {
@@ -2416,7 +2427,7 @@ main {
 
 .section__header {
     display: grid;
-    gap: 0.75rem;
+    gap: clamp(0.4rem, 1.2vw, 0.65rem);
 }
 
 .section__header h2 {


### PR DESCRIPTION
## Summary
- decrease the default gap in shared section layouts to bring headings, paragraphs, and lists closer together
- remove extra margins from top-level paragraphs and lists while keeping list indentation for readability
- tighten spacing within section headers for a more compact layout on research content blocks

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e96b377a54832b8ca21dffd22a76c0