### PR TITLE
Adjust team card spacing and size

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -1777,7 +1777,7 @@ a:focus {
 .team-grid {
     display: grid;
     grid-template-columns: repeat(4, minmax(0, 1fr));
-    gap: clamp(1.15rem, 2.4vw, 1.85rem);
+    gap: clamp(0.9rem, 2vw, 1.5rem);
 }
 
 .team-card {
@@ -1793,7 +1793,7 @@ a:focus {
 }
 
 .team-card__figure {
-    --team-card-portrait-size: clamp(11rem, 70%, 14rem);
+    --team-card-portrait-size: clamp(12rem, 72%, 15rem);
     margin: 0;
     display: grid;
     place-items: center;


### PR DESCRIPTION
## Summary
- reduce the spacing between team member cards so they sit closer together
- enlarge the portrait size within each card to make the cards feel more prominent

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68e97033f510832ba70ff34e92e2ce3f