### PR TITLE
Increase about section scroll offset

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -916,7 +916,7 @@ a:focus {
 }
 
 #about-title {
-    scroll-margin-top: calc(var(--header-offset) + 1.5rem);
+    scroll-margin-top: calc(var(--header-offset) + 10rem);
 }
 
 .about-layout {


### PR DESCRIPTION
## Summary
- increase the scroll margin for the "What is AWARENET?" heading so it clears the sticky navbar when navigated via the hero link

## Testing
- no tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68e970243d38832b81e91ff9233143bf