### PR TITLE
Enlarge team hero heading

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -561,7 +561,7 @@ a:focus {
 
 .hero-institutions h1 {
     color: #1b2c4d;
-    font-size: clamp(2.8rem, 5.5vw, 4.25rem);
+    font-size: clamp(3.133rem, calc(5.5vw + 0.333rem), 4.583rem);
     letter-spacing: -0.01em;
     margin: 0;
     white-space: normal;


### PR DESCRIPTION
## Summary
- increase the team page hero heading font-size by roughly 4pt to improve prominence across viewports

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e9760d85e8832b8a210ecb0bb083e2