### PR TITLE
Delay mail redirect to show toast

### DIFF
--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -689,9 +689,11 @@ document.addEventListener('DOMContentLoaded', () => {
                         }
                     })
                     .finally(() => {
+                        const redirectDelay = toast ? 600 : 100;
+
                         window.setTimeout(() => {
                             window.location.href = mailto;
-                        }, 100);
+                        }, redirectDelay);
                     });
             });
         });


### PR DESCRIPTION
## Summary
- delay the mailto redirect to give the toast notification time to appear when copying email links

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e977a14824832b8e3530a8e2e16dac