### PR TITLE
Reduce workflow illustration size on research page

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -2492,15 +2492,12 @@ main {
 }
 
 .research-workflow__illustration {
-    width: min(960px, 100%);
-    aspect-ratio: 16 / 9;
+    width: min(720px, 100%);
+    height: auto;
     border-radius: 0;
     border: 1px solid var(--surface-border);
     background-color: var(--color-surface);
-    background-image: var(--workflow-figure-image);
-    background-size: cover;
-    background-position: center;
-    background-repeat: no-repeat;
+    display: block;
 }
 
 .research-workflow__figure figcaption {

--- a/research.html
+++ b/research.html
@@ -81,7 +81,7 @@
                 <h2 id="research-workflow-title">Workflow</h2>
             </div>
             <figure class="research-workflow__figure">
-                <img src="assets/images/research/workflow.png" alt="Researchers networking during the Retreat 2025 in Parma" loading="lazy">
+                <img class="research-workflow__illustration" src="assets/images/research/workflow.png" alt="Researchers networking during the Retreat 2025 in Parma" loading="lazy">
                 <figcaption>Workflow of the project methodology. Tasks 1–2: build PCI and tonicity maps; Task 3: situate them within large-scale gradients; Task 4: develop predictive models of lesion impact.</figcaption>
             </figure>
         </section>


### PR DESCRIPTION
## Summary
- add a dedicated class to the research workflow image so its size can be controlled via CSS
- shrink the maximum width of the workflow illustration to avoid an oversized image on the research page

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e979277d0c832b979ec15430d6a994