### PR TITLE
Align research workflow caption with figure

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -2485,10 +2485,12 @@ main {
 }
 
 .research-workflow__figure {
-    margin: 0;
-    display: grid;
-    gap: 1rem;
-    justify-items: center;
+    margin: 0 auto;
+    width: min(720px, 100%);
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 0.75rem;
 }
 
 .research-workflow__illustration {
@@ -2503,7 +2505,7 @@ main {
 .research-workflow__figure figcaption {
     font-size: 0.95rem;
     color: var(--color-muted);
-    text-align: center;
+    text-align: left;
 }
 
 .research-tasks__grid {


### PR DESCRIPTION
## Summary
- center the workflow figure while constraining its width to match the illustration
- align the workflow caption with the left edge of the figure and fine-tune the spacing

## Testing
- no automated tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68e97b24b728832b91ad76cfab20eae1