### PR TITLE
Add hero illustration to research hero section

### DIFF
--- a/research.html
+++ b/research.html
@@ -35,6 +35,9 @@
                 <div class="research-hero__content">
                     <h1 id="research-hero-title">Interdisciplinary research that keeps humans in the loop</h1>
                 </div>
+                <figure class="research-hero__figure">
+                    <img class="research-hero__illustration" src="assets/images/research/hero-brain-network.png" alt="Stylized human head silhouette highlighting connected brain regions">
+                </figure>
             </div>
         </section>
 


### PR DESCRIPTION
## Summary
- add a hero figure to the research landing section so a brain illustration can appear on the right side

## Testing
- no automated tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68e97bdf8b0c832b95798aacf4191933