### PR TITLE
Use timeline layout for research objectives

### DIFF
--- a/research.html
+++ b/research.html
@@ -66,17 +66,29 @@
             </ul>
         </section>
 
-        <section id="research-whatwedo" class="section" aria-labelledby="research-whatwedo-title">
-            <div class="section__header">
+        <section id="research-whatwedo" class="section section--muted" aria-labelledby="research-whatwedo-title">
+            <div class="section__heading">
                 <h2 id="research-whatwedo-title">What we aim to do</h2>
+                <p>AWARENET will:</p>
             </div>
-            <p>AWARENET will:</p>
-            <ul>
-                <li>Map brain regions supporting level and content of consciousness through intracranial perturbations and recordings (sEEG).</li>
-                <li>Integrate these maps with large-scale cortical gradients derived from normative fMRI/dMRI datasets (HCP 7T).</li>
-                <li>Test causality by studying patients undergoing controlled thermocoagulation lesions, comparing behavioral decline with disconnection-overlap in the atlas.</li>
-                <li>Develop tools that predict how specific lesions alter awareness, bridging basic and clinical neuroscience.</li>
-            </ul>
+            <div class="timeline" aria-label="Research objectives">
+                <div class="timeline__event">
+                    <span class="timeline__year">Map consciousness networks</span>
+                    <p>Identify brain regions supporting the level and content of consciousness through intracranial perturbations and recordings (sEEG).</p>
+                </div>
+                <div class="timeline__event">
+                    <span class="timeline__year">Integrate normative gradients</span>
+                    <p>Align intracranial maps with large-scale cortical gradients derived from normative fMRI/dMRI datasets (HCP 7T).</p>
+                </div>
+                <div class="timeline__event">
+                    <span class="timeline__year">Test causal mechanisms</span>
+                    <p>Study patients undergoing controlled thermocoagulation lesions to compare behavioral decline with disconnection-overlap in the atlas.</p>
+                </div>
+                <div class="timeline__event">
+                    <span class="timeline__year">Deliver predictive tools</span>
+                    <p>Develop models that forecast how specific lesions alter awareness, bridging basic and clinical neuroscience.</p>
+                </div>
+            </div>
         </section>
 
         <section id="research-workflow" class="section research-workflow" aria-labelledby="research-workflow-title">


### PR DESCRIPTION
## Summary
- restyled the "What we aim to do" research section with the existing muted section and timeline pattern
- added concise timeline labels and descriptions for each project objective

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e97e04fa74832bb9d0e80c54106da7