### PR TITLE
Refine research objectives layout

### DIFF
--- a/research.html
+++ b/research.html
@@ -66,17 +66,29 @@
             </ul>
         </section>
 
-        <section id="research-whatwedo" class="section" aria-labelledby="research-whatwedo-title">
-            <div class="section__header">
+        <section id="research-whatwedo" class="section section--muted" aria-labelledby="research-whatwedo-title">
+            <div class="section__heading">
                 <h2 id="research-whatwedo-title">What we aim to do</h2>
+                <p>AWARENET will:</p>
             </div>
-            <p>AWARENET will:</p>
-            <ul>
-                <li>Map brain regions supporting level and content of consciousness through intracranial perturbations and recordings (sEEG).</li>
-                <li>Integrate these maps with large-scale cortical gradients derived from normative fMRI/dMRI datasets (HCP 7T).</li>
-                <li>Test causality by studying patients undergoing controlled thermocoagulation lesions, comparing behavioral decline with disconnection-overlap in the atlas.</li>
-                <li>Develop tools that predict how specific lesions alter awareness, bridging basic and clinical neuroscience.</li>
-            </ul>
+            <div class="timeline" aria-label="Research objectives">
+                <div class="timeline__event">
+                    <span class="timeline__year">Map consciousness networks</span>
+                    <p>Identify brain regions supporting the level and content of consciousness through intracranial perturbations and recordings (sEEG).</p>
+                </div>
+                <div class="timeline__event">
+                    <span class="timeline__year">Integrate normative gradients</span>
+                    <p>Align intracranial maps with large-scale cortical gradients derived from normative fMRI/dMRI datasets (HCP 7T).</p>
+                </div>
+                <div class="timeline__event">
+                    <span class="timeline__year">Test causal mechanisms</span>
+                    <p>Study patients undergoing controlled thermocoagulation lesions to compare behavioral decline with disconnection-overlap in the atlas.</p>
+                </div>
+                <div class="timeline__event">
+                    <span class="timeline__year">Deliver predictive tools</span>
+                    <p>Develop models that forecast how specific lesions alter awareness, bridging basic and clinical neuroscience.</p>
+                </div>
+            </div>
         </section>
 
         <section id="research-workflow" class="section research-workflow" aria-labelledby="research-workflow-title">


### PR DESCRIPTION
## Summary
- restyle the research objectives section with the muted section styling and timeline layout
- replace the unordered list with timeline events that highlight each project objective

## Testing
- no tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68e982d5b4b4832bb168d81f51e24ec3