### PR TITLE
Refine research hero image styling

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -2395,7 +2395,7 @@ main {
 
 .research-hero__grid {
     display: grid;
-    grid-template-columns: minmax(0, 1fr) minmax(0, 480px);
+    grid-template-columns: minmax(0, 1fr) minmax(0, clamp(340px, 42vw, 560px));
     gap: clamp(2rem, 5vw, 4rem);
     align-items: center;
     width: min(1100px, 100%);
@@ -2414,16 +2414,17 @@ main {
 
 .research-hero__figure {
     margin: 0;
+    display: flex;
+    justify-content: center;
 }
 
 .research-hero__illustration {
-    width: 100%;
-    aspect-ratio: 4 / 3;
-    border-radius: 0;
-    border: 1px solid var(--surface-border);
-    background-color: var(--color-surface);
+    width: min(100%, clamp(320px, 48vw, 560px));
+    height: auto;
+    border: none;
+    background: transparent;
     background-image: var(--hero-figure-image);
-    background-size: cover;
+    background-size: contain;
     background-position: center;
     background-repeat: no-repeat;
 }


### PR DESCRIPTION
## Summary
- widen the research hero layout to give the illustration more visual space
- remove forced aspect ratio, border, and background so the hero image renders at its natural proportions without a white box

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e983839d84832b998d0ec5de2ff384