### PR TITLE
Fix stray conflict URL showing in research navbar

### DIFF
--- a/research.html
+++ b/research.html
@@ -18,7 +18,7 @@
                     <span class="navbar__title">AWARE<span class="navbar__title--accent">NET</span></span>
                 </span>
             </a>
-            <button class="navbar__toggle" aria-expanded="false" aria-controls="primary-navigation">☰</button>https://github.com/awarenetproject/awarenetproject.github.io/pull/249/conflict?name=assets%252Fcss%252Fstyles.css&ancestor_oid=29a10efbafd801cc18169fd2149683f9450c7eea&base_oid=0841580c767ad3bfcfa0c168fa4e3f36d5b3fe93&head_oid=76903d387a65050892685761102e8be9d8c59c0d
+            <button class="navbar__toggle" aria-expanded="false" aria-controls="primary-navigation">☰</button>
             <ul id="primary-navigation" class="navbar__menu">
                 <li class="navbar__item"><a href="index.html" class="navbar__link">Home</a></li>
                 <li class="navbar__item"><a href="research.html" class="navbar__link navbar__link--active">Research</a></li>


### PR DESCRIPTION
## Summary
- remove the accidental conflict URL that was appended to the research page navbar toggle

## Testing
- not run (static site change)


------
https://chatgpt.com/codex/tasks/task_e_68ecf83081f0832ba307c5ef95f03aa7