### PR TITLE
Center research challenge highlight card

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -2555,6 +2555,8 @@ main {
     border-color: rgba(255, 255, 255, 0.2);
     color: #ffffff;
     box-shadow: 0 14px 28px rgba(58, 104, 153, 0.28);
+    width: min(100%, 520px);
+    justify-self: center;
 }
 
 .research-dual__item--contrast h3 {


### PR DESCRIPTION
## Summary
- limit the width of the contrast highlight card in the research challenges section
- center the highlight card within its grid column for a more balanced layout

## Testing
- no tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68ecf98fdadc832b981bf3c6dfb64bf0