### PR TITLE
Add partner logo to navbar brand

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -229,6 +229,12 @@ a:focus {
     box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.55), 0 12px 24px var(--crest-shadow);
 }
 
+.navbar__partner {
+    height: 2.4rem;
+    width: auto;
+    display: block;
+}
+
 .navbar__crest::after {
     content: "";
     position: absolute;

--- a/index.html
+++ b/index.html
@@ -15,6 +15,7 @@
         <nav class="navbar">
             <a class="navbar__brand" href="index.html" aria-label="AWARENET">
                 <span class="navbar__crest" aria-hidden="true"></span>
+                <img class="navbar__partner" src="assets/images/team/uni_icons/cariparo.png" alt="Fondazione Cariparo logo">
                 <span class="navbar__identity">
                     <span class="navbar__title">AWARE<span class="navbar__title--accent">NET</span></span>
                 </span>


### PR DESCRIPTION
## Summary
- add the Fondazione Cariparo logo to the homepage navbar brand area
- style the navbar partner logo so it aligns with the existing crest

## Testing
- no automated tests were run (static site)


------
https://chatgpt.com/codex/tasks/task_e_69008ea1a584832bae48bb0e64201dac