### PR TITLE
Add template card to team page for future members

### DIFF
--- a/team.html
+++ b/team.html
@@ -236,6 +236,36 @@
                         </li>
                     </ul>
                 </article>
+                <!-- Template card for new team members. Replace placeholder content with the new person's details. -->
+                <article class="team-card">
+                    <figure class="team-card__figure">
+                        <img class="team-card__portrait" src="assets/images/team/people_photos/profile-placeholder.svg" alt="Placeholder profile silhouette">
+                    </figure>
+                    <h3 class="team-card__name">Full Name</h3>
+                    <p class="team-card__role">Role or Title</p>
+                    <ul class="team-card__links" aria-label="Full Name contact options">
+                        <li>
+                            <a class="team-card__link" href="mailto:replace.this.email@example.com" data-email-link data-email="replace.this.email@awarenet.org" aria-label="Email Full Name">
+                                <img class="team-card__icon" src="assets/images/team/icons/mail.jpg" alt="Mail icon">
+                            </a>
+                        </li>
+                        <li>
+                            <a class="team-card__link" href="https://scholar.google.com" aria-label="Visit Full Name's Google Scholar profile">
+                                <img class="team-card__icon" src="assets/images/team/icons/googlescholar.png" alt="Google Scholar icon">
+                            </a>
+                        </li>
+                        <li>
+                            <a class="team-card__link" href="https://example.com" aria-label="Visit Full Name's website">
+                                <img class="team-card__icon" src="assets/images/team/icons/website.jpg" alt="Website icon">
+                            </a>
+                        </li>
+                        <li>
+                            <a class="team-card__link" href="https://www.linkedin.com" aria-label="Visit Full Name on LinkedIn">
+                                <img class="team-card__icon" src="assets/images/team/icons/linkeding.svg" alt="LinkedIn icon">
+                            </a>
+                        </li>
+                    </ul>
+                </article>
             </div>
         </section>
     </main>


### PR DESCRIPTION
## Summary
- add a placeholder team card at the end of the team grid so new members can be added quickly
- include sample contact links, placeholder email data, and guidance comment for easy customization

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6913405eb9f8832b978b991ae9b8e00b)