### PR TITLE
Remove CNR logo from navbar

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Tutte le pagine condividono la stessa barra di navigazione responsive e il foote
 
 ## Personalizzazione rapida
 
-1. **Logo e identità** – aggiorna l'elemento `.navbar__crest` o sostituisci `assets/images/logo.png` con il tuo logo.
+1. **Logo e identità** – aggiorna l'immagine dentro `.navbar__logos` oppure sostituisci `assets/images/logo.png` con il tuo logo.
 2. **Contenuti** – modifica testi direttamente nei file HTML; ogni sezione è già organizzata con classi semantiche (`section__heading`, `card-grid`, ecc.).
 3. **Eventi** – duplica `event.html` per creare landing dedicate oppure collega dalla pagina `news.html` aggiungendo il parametro `title` all'URL per personalizzare il titolo in modo rapido.
 4. **Immagini del team** – carica le foto in `assets/photos_team` oppure sostituisci i segnaposto in `assets/images/placeholders/` con versioni reali (consigliata la stessa proporzione per mantenere il layout).

--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -220,28 +220,16 @@ a:focus {
     transform: none;
 }
 
-.navbar__crest {
-    width: 3.35rem;
-    height: 3.35rem;
-    border-radius: 1.5rem;
-    background: var(--gradient-crest);
-    position: relative;
-    box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.55), 0 12px 24px var(--crest-shadow);
+.navbar__logos {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.75rem;
 }
 
 .navbar__partner {
     height: 2.75rem;
     width: auto;
     display: block;
-}
-
-.navbar__crest::after {
-    content: "";
-    position: absolute;
-    inset: 22% 22% 18% 18%;
-    border-radius: 1.1rem;
-    background: rgba(255, 255, 255, 0.75);
-    mix-blend-mode: screen;
 }
 
 .navbar__identity {
@@ -2301,9 +2289,8 @@ main {
         padding: 0.35rem 0.5rem;
     }
 
-    .navbar__crest {
-        width: 2.9rem;
-        height: 2.9rem;
+    .navbar__logos {
+        gap: 0.6rem;
     }
 
     .navbar__eyebrow {

--- a/contact.html
+++ b/contact.html
@@ -13,8 +13,9 @@
     <header class="site-header">
         <nav class="navbar">
             <a class="navbar__brand" href="index.html" aria-label="AWARENET">
-                <img class="navbar__partner" src="assets/images/team/uni_icons/cariparo.png" alt="Fondazione Cariparo logo">
-                <span class="navbar__crest" aria-hidden="true"></span>
+                <span class="navbar__logos">
+                    <img class="navbar__partner" src="assets/images/team/uni_icons/cariparo.png" alt="Fondazione Cariparo logo">
+                </span>
                 <span class="navbar__identity">
                     <span class="navbar__title">AWARE<span class="navbar__title--accent">NET</span></span>
                 </span>

--- a/event.html
+++ b/event.html
@@ -14,8 +14,9 @@
     <header class="site-header">
         <nav class="navbar">
             <a class="navbar__brand" href="index.html" aria-label="AWARENET">
-                <img class="navbar__partner" src="assets/images/team/uni_icons/cariparo.png" alt="Fondazione Cariparo logo">
-                <span class="navbar__crest" aria-hidden="true"></span>
+                <span class="navbar__logos">
+                    <img class="navbar__partner" src="assets/images/team/uni_icons/cariparo.png" alt="Fondazione Cariparo logo">
+                </span>
                 <span class="navbar__identity">
                     <span class="navbar__title">AWARE<span class="navbar__title--accent">NET</span></span>
                 </span>

--- a/events/event-template.html
+++ b/events/event-template.html
@@ -13,7 +13,9 @@
     <header class="site-header">
         <nav class="navbar">
             <a class="navbar__brand" href="../index.html" aria-label="AWARENET">
-                <span class="navbar__crest" aria-hidden="true"></span>
+                <span class="navbar__logos">
+                    <img class="navbar__partner" src="../assets/images/team/uni_icons/cariparo.png" alt="Fondazione Cariparo logo">
+                </span>
                 <span class="navbar__identity">
                     <span class="navbar__title">AWARE<span class="navbar__title--accent">NET</span></span>
                 </span>

--- a/events/retreat-2025.html
+++ b/events/retreat-2025.html
@@ -13,7 +13,9 @@
     <header class="site-header">
         <nav class="navbar">
             <a class="navbar__brand" href="../index.html" aria-label="AWARENET">
-                <span class="navbar__crest" aria-hidden="true"></span>
+                <span class="navbar__logos">
+                    <img class="navbar__partner" src="../assets/images/team/uni_icons/cariparo.png" alt="Fondazione Cariparo logo">
+                </span>
                 <span class="navbar__identity">
                     <span class="navbar__title">AWARE<span class="navbar__title--accent">NET</span></span>
                 </span>

--- a/index.html
+++ b/index.html
@@ -13,8 +13,9 @@
     <header class="site-header">
         <nav class="navbar">
             <a class="navbar__brand" href="index.html" aria-label="AWARENET">
-                <img class="navbar__partner" src="assets/images/team/uni_icons/cariparo.png" alt="Fondazione Cariparo logo">
-                <span class="navbar__crest" aria-hidden="true"></span>
+                <span class="navbar__logos">
+                    <img class="navbar__partner" src="assets/images/team/uni_icons/cariparo.png" alt="Fondazione Cariparo logo">
+                </span>
                 <span class="navbar__identity">
                     <span class="navbar__title">AWARE<span class="navbar__title--accent">NET</span></span>
                 </span>

--- a/news.html
+++ b/news.html
@@ -13,8 +13,9 @@
     <header class="site-header">
         <nav class="navbar">
             <a class="navbar__brand" href="index.html" aria-label="AWARENET">
-                <img class="navbar__partner" src="assets/images/team/uni_icons/cariparo.png" alt="Fondazione Cariparo logo">
-                <span class="navbar__crest" aria-hidden="true"></span>
+                <span class="navbar__logos">
+                    <img class="navbar__partner" src="assets/images/team/uni_icons/cariparo.png" alt="Fondazione Cariparo logo">
+                </span>
                 <span class="navbar__identity">
                     <span class="navbar__title">AWARE<span class="navbar__title--accent">NET</span></span>
                 </span>

--- a/parma_retreat.html
+++ b/parma_retreat.html
@@ -13,8 +13,9 @@
     <header class="site-header">
         <nav class="navbar">
             <a class="navbar__brand" href="index.html" aria-label="AWARENET">
-                <img class="navbar__partner" src="assets/images/team/uni_icons/cariparo.png" alt="Fondazione Cariparo logo">
-                <span class="navbar__crest" aria-hidden="true"></span>
+                <span class="navbar__logos">
+                    <img class="navbar__partner" src="assets/images/team/uni_icons/cariparo.png" alt="Fondazione Cariparo logo">
+                </span>
                 <span class="navbar__identity">
                     <span class="navbar__title">AWARE<span class="navbar__title--accent">NET</span></span>
                 </span>

--- a/research.html
+++ b/research.html
@@ -13,8 +13,9 @@
     <header class="site-header">
         <nav class="navbar">
             <a class="navbar__brand" href="index.html" aria-label="AWARENET">
-                <img class="navbar__partner" src="assets/images/team/uni_icons/cariparo.png" alt="Fondazione Cariparo logo">
-                <span class="navbar__crest" aria-hidden="true"></span>
+                <span class="navbar__logos">
+                    <img class="navbar__partner" src="assets/images/team/uni_icons/cariparo.png" alt="Fondazione Cariparo logo">
+                </span>
                 <span class="navbar__identity">
                     <span class="navbar__title">AWARE<span class="navbar__title--accent">NET</span></span>
                 </span>

--- a/team.html
+++ b/team.html
@@ -13,8 +13,9 @@
     <header class="site-header">
         <nav class="navbar">
             <a class="navbar__brand" href="index.html" aria-label="AWARENET">
-                <img class="navbar__partner" src="assets/images/team/uni_icons/cariparo.png" alt="Fondazione Cariparo logo">
-                <span class="navbar__crest" aria-hidden="true"></span>
+                <span class="navbar__logos">
+                    <img class="navbar__partner" src="assets/images/team/uni_icons/cariparo.png" alt="Fondazione Cariparo logo">
+                </span>
                 <span class="navbar__identity">
                     <span class="navbar__title">AWARE<span class="navbar__title--accent">NET</span></span>
                 </span>


### PR DESCRIPTION
## Summary
- remove the Consiglio Nazionale delle Ricerche logo from the shared navbar across every page
- update the README customization note to reference the single logo slot

## Testing
- no tests were run (static site)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6913403a10dc832bb75cff8b39c72834)