### PR TITLE
Center Catalina Campuzano portrait on team page

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -1825,6 +1825,10 @@ a:focus {
     border-radius: 0;
 }
 
+.team-card__portrait--catalina {
+    object-position: center 35%;
+}
+
 .team-card__name {
     margin: 0;
     color: #1f2d44;

--- a/team.html
+++ b/team.html
@@ -238,7 +238,7 @@
                 </article>
                 <article class="team-card">
                     <figure class="team-card__figure">
-                        <img class="team-card__portrait" src="assets/images/team/people_photos/catalina.jpg" alt="Placeholder profile silhouette">
+                        <img class="team-card__portrait team-card__portrait--catalina" src="assets/images/team/people_photos/catalina.jpg" alt="Placeholder profile silhouette">
                     </figure>
                     <h3 class="team-card__name">Catalina Campuzano</h3>
                     <p class="team-card__role">PhD Student</p>


### PR DESCRIPTION
## Summary
- add a modifier class to Catalina Campuzano's portrait on the team page
- tweak the portrait's object position so the face is centered within the frame

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691342e1a698832b90e211359fbac3d4)