### PR TITLE
Adjust Catalina portrait alignment

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -1814,7 +1814,7 @@ a:focus {
 }
 
 .team-card__portrait--catalina {
-    object-position: center 35%;
+    object-position: center 48%;
 }
 
 .team-card__name {


### PR DESCRIPTION
## Summary
- adjust the Catalina portrait cropping to better center the face within the existing card layout

## Testing
- not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691346db3b1c832bbe87d3137abd827f)